### PR TITLE
Allow multiple behavior loading.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+indent_style = space

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -57,6 +57,7 @@ class TagBehavior extends Behavior {
 		],
 		'finderField' => 'tag',
 		'fkModelField' => 'fk_model',
+		'fkModelAlias' => null,
 	];
 
 	/**
@@ -187,7 +188,8 @@ class TagBehavior extends Behavior {
 		$table = $this->_table;
 		$tableAlias = $this->_table->getAlias();
 
-		$assocConditions = [$taggedAlias . '.' . $this->getConfig('fkModelField') => $table->getAlias()];
+		$modelAlias = $this->getConfig('fkModelAlias') ?: $tableAlias;
+		$assocConditions = [$taggedAlias . '.' . $this->getConfig('fkModelField') => $modelAlias];
 
 		if (!$table->hasAssociation($taggedAlias)) {
 			$table->hasMany($taggedAlias, $taggedAssoc + [
@@ -199,7 +201,7 @@ class TagBehavior extends Behavior {
 		if (!$table->hasAssociation($tagsAlias)) {
 			$table->belongsToMany($tagsAlias, $tagsAssoc + [
 				'through' => $table->{$taggedAlias}->getTarget(),
-				'conditions' => $assocConditions
+				'conditions' => $assocConditions,
 			]);
 		}
 
@@ -353,7 +355,9 @@ class TagBehavior extends Behavior {
 
 		$result = [];
 
-		$common = ['_joinData' => [$this->getConfig('fkModelField') => $this->_table->getAlias()]];
+		$modelAlias = $this->getConfig('fkModelAlias') ?: $this->_table->getAlias();
+
+		$common = ['_joinData' => [$this->getConfig('fkModelField') => $modelAlias]];
 		$namespace = $this->getConfig('namespace');
 		if ($namespace) {
 			$common += compact('namespace');

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -284,7 +284,7 @@ class TagBehavior extends Behavior {
 	}
 
 	/**
-	 * @param string|array
+	 * @param string|array $config
 	 * @return array
 	 */
 	protected function _getTaggedCounterConfig($config) {

--- a/tests/Fixture/MultiTagsRecordsFixture.php
+++ b/tests/Fixture/MultiTagsRecordsFixture.php
@@ -11,6 +11,8 @@ class MultiTagsRecordsFixture extends TestFixture {
 	public $fields = [
 		'id' => ['type' => 'integer', 'length' => 10, 'autoIncrement' => true],
 		'name' => ['type' => 'string', 'length' => 255],
+		'one_count' => ['type' => 'integer', 'null' => false, 'default' => 0],
+		'two_count' => ['type' => 'integer', 'null' => false, 'default' => 0],
 		'_constraints' => [
 			'primary' => ['type' => 'primary', 'columns' => ['id']],
 		],
@@ -22,9 +24,13 @@ class MultiTagsRecordsFixture extends TestFixture {
 	public $records = [
 		[
 			'name' => 'square',
+			'one_count' => 0,
+			'two_count' => 0,
 		],
 		[
 			'name' => 'round',
+			'one_count' => 0,
+			'two_count' => 0,
 		],
 	];
 

--- a/tests/Fixture/MultiTagsRecordsFixture.php
+++ b/tests/Fixture/MultiTagsRecordsFixture.php
@@ -1,0 +1,31 @@
+<?php
+namespace Tags\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class MultiTagsRecordsFixture extends TestFixture {
+
+	/**
+	 * @var array
+	 */
+	public $fields = [
+		'id' => ['type' => 'integer', 'length' => 10, 'autoIncrement' => true],
+		'name' => ['type' => 'string', 'length' => 255],
+		'_constraints' => [
+			'primary' => ['type' => 'primary', 'columns' => ['id']],
+		],
+	];
+
+	/**
+	 * @var array
+	 */
+	public $records = [
+		[
+			'name' => 'square',
+		],
+		[
+			'name' => 'round',
+		],
+	];
+
+}

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -90,20 +90,33 @@ class TagsTableTest extends TestCase {
 		$entity = $table->newEntity([
 			'name' => 'Föö Bää',
 			'one_list' => 'x,y',
-			'two_list' => '12, 66',
+			'two_list' => '12, 66, 98',
 		]);
 		$one = Hash::extract($entity->one, '{n}.label');
 		$this->assertSame(['x', 'y'], $one);
 
 		$two = Hash::extract($entity->two, '{n}.label');
-		$this->assertSame(['12', '66'], $two);
+		$this->assertSame(['12', '66', '98'], $two);
 
 		$table->saveOrFail($entity);
 
 		$entity = $table->get($entity->id, ['contain' => ['TagsOne', 'TagsTwo']]);
 
 		$this->assertSame('x, y', $entity->one_list);
-		$this->assertSame('12, 66', $entity->two_list);
+		$this->assertSame('12, 66, 98', $entity->two_list);
+
+		$this->assertSame(2, $entity->one_count);
+		$this->assertSame(3, $entity->two_count);
+
+		$untagged = $table->find('untaggedOne')->count();
+		$this->assertSame(2, $untagged);
+		$tagged = $table->find('taggedOne', ['tag' => 'x'])->first();
+		$this->assertSame($entity->id, $tagged->id);
+
+		$untagged = $table->find('untaggedTwo')->count();
+		$this->assertSame(2, $untagged);
+		$tagged = $table->find('taggedTwo', ['tag' => '66'])->first();
+		$this->assertSame($entity->id, $tagged->id);
 	}
 
 }

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -4,6 +4,7 @@ namespace Tags\Test\TestCase\Model\Table;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use Tools\Utility\Text;
 
 class TagsTableTest extends TestCase {
@@ -14,7 +15,9 @@ class TagsTableTest extends TestCase {
 	 * @var array
 	 */
 	public $fixtures = [
-		'plugin.tags.tags',
+		'plugin.Tags.Tags',
+		'plugin.Tags.Tagged',
+		'plugin.Tags.MultiTagsRecords',
 	];
 
 	/**
@@ -74,6 +77,33 @@ class TagsTableTest extends TestCase {
 
 		$this->Tags->saveOrFail($tag);
 		$this->assertSame('Foo-Baa', $tag->slug);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMultipleTagsPerModel() {
+		TableRegistry::clear();
+
+		$table = TableRegistry::get('MultiTagsRecords');
+
+		$entity = $table->newEntity([
+			'name' => 'Föö Bää',
+			'one_list' => 'x,y',
+			'two_list' => '12, 66',
+		]);
+		$one = Hash::extract($entity->one, '{n}.label');
+		$this->assertSame(['x', 'y'], $one);
+
+		$two = Hash::extract($entity->two, '{n}.label');
+		$this->assertSame(['12', '66'], $two);
+
+		$table->saveOrFail($entity);
+
+		$entity = $table->get($entity->id, ['contain' => ['TagsOne', 'TagsTwo']]);
+
+		$this->assertSame('x, y', $entity->one_list);
+		$this->assertSame('12, 66', $entity->two_list);
 	}
 
 }

--- a/tests/test_app/src/Model/Table/MultiTagsRecordsTable.php
+++ b/tests/test_app/src/Model/Table/MultiTagsRecordsTable.php
@@ -25,11 +25,13 @@ class MultiTagsRecordsTable extends Table {
 			'field' => 'one_list',
 			'tagsAlias' => 'TagsOne',
 			'taggedAlias' => 'TaggedOne',
-			'taggedCounter' => false,
+			'taggedCounter' => 'one_count',
 			'tagsAssoc' => [
 				'propertyName' => 'one',
 			],
 			'implementedFinders' => [
+				'taggedOne' => 'findByTag',
+				'untaggedOne' => 'findUntagged',
 			],
 			'implementedMethods' => [
 			],
@@ -40,11 +42,13 @@ class MultiTagsRecordsTable extends Table {
 			'field' => 'two_list',
 			'tagsAlias' => 'TagsTwo',
 			'taggedAlias' => 'TaggedTwo',
-			'taggedCounter' => false,
+			'taggedCounter' => 'two_count',
 			'tagsAssoc' => [
 				'propertyName' => 'two',
 			],
 			'implementedFinders' => [
+				'taggedTwo' => 'findByTag',
+				'untaggedTwo' => 'findUntagged',
 			],
 			'implementedMethods' => [
 			],

--- a/tests/test_app/src/Model/Table/MultiTagsRecordsTable.php
+++ b/tests/test_app/src/Model/Table/MultiTagsRecordsTable.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \Tags\Model\Table\TaggedTable|\Cake\ORM\Association\HasMany $TaggedOne
+ * @property \Tags\Model\Table\TagsTable|\Cake\ORM\Association\BelongsToMany $TagsOne
+ * @property \Tags\Model\Table\TaggedTable|\Cake\ORM\Association\HasMany $TaggedTwo
+ * @property \Tags\Model\Table\TagsTable|\Cake\ORM\Association\BelongsToMany $TagsTwo
+ *
+ * @mixin \Tags\Model\Behavior\TagBehavior
+ */
+class MultiTagsRecordsTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config) {
+		$this->addBehavior('TagsOne', [
+			'className' => 'Tags.Tag',
+			'fkModelAlias' => 'MultiTagsRecordsOne',
+			'field' => 'one_list',
+			'tagsAlias' => 'TagsOne',
+			'taggedAlias' => 'TaggedOne',
+			'taggedCounter' => false,
+			'tagsAssoc' => [
+				'propertyName' => 'one',
+			],
+			'implementedFinders' => [
+			],
+			'implementedMethods' => [
+			],
+		]);
+		$this->addBehavior('TagsTwo', [
+			'className' => 'Tags.Tag',
+			'fkModelAlias' => 'MultiTagsRecordsTwo',
+			'field' => 'two_list',
+			'tagsAlias' => 'TagsTwo',
+			'taggedAlias' => 'TaggedTwo',
+			'taggedCounter' => false,
+			'tagsAssoc' => [
+				'propertyName' => 'two',
+			],
+			'implementedFinders' => [
+			],
+			'implementedMethods' => [
+			],
+		]);
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-tags/issues/20 ?

Tricky, as lots of things need to be configured via aliasing now.

The trick here is to use a new config

    'fkModelAlias' => 'MyTable{suffix}',

see docs