### PR TITLE
Uniqueness fix on saveMany()

### DIFF
--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -58,6 +58,7 @@ class TagBehavior extends Behavior {
 		'finderField' => 'tag',
 		'fkModelField' => 'fk_model',
 		'fkModelAlias' => null,
+		'slug' => null,
 	];
 
 	/**
@@ -417,6 +418,14 @@ class TagBehavior extends Behavior {
 	 * @return string
 	 */
 	protected function _getTagKey($tag) {
+		$slug = $this->getConfig('slug');
+		if ($slug) {
+			if (!is_callable($slug)) {
+				throw new RuntimeException('You must use a valid callable for custom slugging.');
+			}
+			return $slug($tag);
+		}
+
 		return mb_strtolower(Text::slug($tag));
 	}
 

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -423,15 +423,15 @@ class TagBehavior extends Behavior {
 	/**
 	 * Checks if a tag already exists and returns the id if yes.
 	 *
-	 * @param string $tag Tag key.
+	 * @param string $slug Tag key.
 	 * @return null|int
 	 */
-	protected function _tagExists($tag) {
+	protected function _tagExists($slug) {
 		$tagsTable = $this->_table->{$this->getConfig('tagsAlias')}->getTarget();
 
 		$result = $tagsTable->find()
 			->where([
-				$tagsTable->aliasField('slug') => $tag,
+				$tagsTable->aliasField('slug') => $slug,
 			])
 			->select([
 				$tagsTable->aliasField($tagsTable->getPrimaryKey())

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -70,7 +70,12 @@ class TagsTable extends Table {
 			->allowEmpty('id', 'create');
 
 		$validator
-			->notBlank('slug');
+			->notBlank('slug')
+			->add('slug', 'isUnique', [
+				'rule' => ['validateUnique', ['scope' => 'namespace']],
+				'message' => __('Already exists'),
+				'provider' => 'table'
+			]);
 
 		$validator
 			->notBlank('label');

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -39,11 +39,11 @@ class TagsTable extends Table {
 		}
 		if ($slugger === true) {
 			if (Plugin::loaded('Tools')) {
-				$this->addBehavior('Tools.Slugged');
+				 //$this->addBehavior('Tools.Slugged');
 				return;
 			}
 			if (Plugin::loaded('Muffin/Slug')) {
-				$this->addBehavior('Muffin/Slug.Slug');
+				//$this->addBehavior('Muffin/Slug.Slug');
 				return;
 			}
 

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -32,18 +32,21 @@ class TagsTable extends Table {
 		$this->setDisplayField('label'); // Change to name?
 		$this->addBehavior('Timestamp');
 
-		/** @var array|bool|string|null $slugger */
+		/**
+		 * @deprecated Should not be used anymore.
+		 * @var array|bool|string|null $slugger
+		 */
 		$slugger = Configure::read('Tags.slugBehavior');
 		if (!$slugger) {
 			return;
 		}
 		if ($slugger === true) {
 			if (Plugin::loaded('Tools')) {
-				 //$this->addBehavior('Tools.Slugged');
+				$this->addBehavior('Tools.Slugged');
 				return;
 			}
 			if (Plugin::loaded('Muffin/Slug')) {
-				//$this->addBehavior('Muffin/Slug.Slug');
+				$this->addBehavior('Muffin/Slug.Slug');
 				return;
 			}
 

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -15,15 +15,18 @@ class TagsFixture extends TestFixture {
 	 */
 	public $fields = [
 		'id' => ['type' => 'integer', 'length' => 11, 'autoIncrement' => true],
-		'namespace' => ['type' => 'string', 'length' => 255, 'null' => true],
-		'slug' => ['type' => 'string', 'length' => 255],
-		'label' => ['type' => 'string', 'length' => 255],
+		'namespace' => ['type' => 'string', 'collate' => 'utf8_unicode_ci', 'length' => 255, 'null' => true],
+		'slug' => ['type' => 'string', 'collate' => 'utf8_unicode_ci', 'length' => 255],
+		'label' => ['type' => 'string', 'collate' => 'utf8_unicode_ci', 'length' => 255],
 		'counter' => ['type' => 'integer', 'unsigned' => true, 'default' => '0', 'null' => false],
 		'created' => ['type' => 'datetime', 'null' => true],
 		'modified' => ['type' => 'datetime', 'null' => true],
 		'_constraints' => [
 			'primary' => ['type' => 'primary', 'columns' => ['id']],
 			'slug' => ['type' => 'unique', 'columns' => ['slug', 'namespace'], 'length' => []],
+		],
+		'_options' => [
+			'collation' => 'utf8_unicode_ci'
 		],
 	];
 

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -1,11 +1,13 @@
 <?php
 namespace Tags\Test\TestCase\Model\Behavior;
 
+use Cake\Core\Configure;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use Cake\Utility\Text;
 
 class TagBehaviorTest extends TestCase {
 
@@ -490,18 +492,25 @@ class TagBehaviorTest extends TestCase {
 	}
 
 	/**
-	 * This works fine on MySQL and other case insensitive DBs.
-	 * For Postgres make sure the slugger returns a lower-cased version!
-	 *
 	 * @return void
 	 */
-	public function _testSaveWithSlug() {
-		$tag = [
-			'label' => 'X Y',
+	public function testSaveWithSlugger() {
+		$this->Table->removeBehavior('Tag');
+
+		$this->Table->addBehavior('Tags.Tag', [
+			'slug' => function ($tag) {
+				return Text::slug($tag);
+			},
+		]);
+
+		$data = [
+			'name' => 'Muffin',
+			'tag_list' => 'Foo Bar',
 		];
-		$tag = $this->Table->Tags->newEntity($tag);
-		$result = $this->Table->Tags->save($tag);
-		$this->assertSame('X-Y', $result->slug);
+		$entity = $this->Table->newEntity($data);
+		$result = $this->Table->save($entity);
+
+		$this->assertSame('Foo-Bar', $result->tags[0]->slug);
 	}
 
 	/**

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Tags\Test\TestCase\Model\Behavior;
 
-use Cake\Core\Configure;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\TableRegistry;
@@ -163,6 +162,39 @@ class TagBehaviorTest extends TestCase {
 		$this->assertEquals(1, $count);
 		$count = $this->Table->Tagged->Tags->find()->where(['label' => 'color'])->count();
 		$this->assertEquals(0, $count);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSaveManyDuplicates() {
+		$entities = [
+			$this->Table->newEntity([
+				'name' => 'Duplicate Tags!',
+				'tag_list' => 'Color, Dark Color',
+			]),
+			$this->Table->newEntity([
+				'name' => 'Duplicate Tags 2!',
+				'tag_list' => 'Dark Color, Light Color',
+			]),
+			$this->Table->newEntity([
+				'name' => 'Duplicate Tags 3!',
+				'tag_list' => 'Light Color, New Color',
+			]),
+		];
+		$result = $this->Table->saveMany($entities);
+		$this->assertTrue((bool)$result);
+
+		$Tags = $this->Table->Tagged->Tags;
+
+		$count = $Tags->find()->where(['label' => 'Color'])->count();
+		$this->assertEquals(1, $count);
+		$count = $Tags->find()->where(['label' => 'Dark Color'])->count();
+		$this->assertEquals(1, $count);
+		$count = $Tags->find()->where(['label' => 'Light Color'])->count();
+		$this->assertEquals(1, $count);
+		$count = $Tags->find()->where(['label' => 'New Color'])->count();
+		$this->assertEquals(1, $count);
 	}
 
 	/**

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -99,7 +99,7 @@ class TagBehaviorTest extends TestCase {
 		/** @var \Tags\Model\Entity\Tag $tag */
 		foreach ($entity->tags as $tag) {
 			//FIXME
-			//$this->assertFalse($tag->isNew());
+			$this->assertFalse($tag->isNew());
 		}
 		$this->Table->saveOrFail($entity);
 	}

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -79,6 +79,9 @@ class TagBehaviorTest extends TestCase {
 			'tag_list' => 'Shiny Thing, Awesome',
 		];
 		$entity = $this->Table->newEntity($data);
+
+		debug($entity);
+
 		$this->Table->saveOrFail($entity);
 
 		$taggedRows = $this->Table->Tagged->find()->contain('Tags')->where(['fk_id' => $entity->id])->all()->toArray();
@@ -95,6 +98,8 @@ class TagBehaviorTest extends TestCase {
 			'tag_list' => 'Shiny Thing, Awesome',
 		];
 		$entity = $this->Table->newEntity($data);
+
+		debug($entity);
 
 		/** @var \Tags\Model\Entity\Tag $tag */
 		foreach ($entity->tags as $tag) {

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -80,8 +80,6 @@ class TagBehaviorTest extends TestCase {
 		];
 		$entity = $this->Table->newEntity($data);
 
-		debug($entity);
-
 		$this->Table->saveOrFail($entity);
 
 		$taggedRows = $this->Table->Tagged->find()->contain('Tags')->where(['fk_id' => $entity->id])->all()->toArray();
@@ -99,16 +97,11 @@ class TagBehaviorTest extends TestCase {
 		];
 		$entity = $this->Table->newEntity($data);
 
-		debug($entity);
-
 		/** @var \Tags\Model\Entity\Tag $tag */
 		foreach ($entity->tags as $tag) {
-			//FIXME
 			$this->assertFalse($tag->isNew());
 		}
 		$this->Table->saveOrFail($entity);
-
-		debug($this->Table->Tagged->Tags->find()->all()->toArray());
 	}
 
 	/**

--- a/tests/TestCase/Model/Behavior/UuidTest.php
+++ b/tests/TestCase/Model/Behavior/UuidTest.php
@@ -68,7 +68,7 @@ class UuidTest extends TestCase {
 		$this->assertCount(2, $savedRecord->tags);
 
 		$tags = $table->Tags->find()->orderAsc('slug')->all()->toArray();
-		$expected = ['Bar', 'Foo'];
+		$expected = ['bar', 'foo'];
 		$this->assertSame($expected, Hash::extract($tags, '{n}.slug'));
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -81,5 +81,3 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 ]);
 
 Configure::write('debug', true);
-
-Configure::write('Tags.slugBehavior', true);

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
 	autoload_files:
 		- %rootDir%/../../../tests/bootstrap.php
 		- %rootDir%/../../../tests/shim.php
+	ignoreErrors:
+		- '#Access to an undefined property .+::\$_joinData.#'


### PR DESCRIPTION
make sure saveMany() with a lot of new tags in patching results in still normalized DB entities (unique).