### PR TITLE
Test or/and filtering.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -166,6 +166,24 @@ $searchManager
     ]);
 ```
 
+##### Or/And
+
+Using `orSeparator`/`andSeparator` config, one can also filter by multiple tags at once:
+```php
+// Records that have either "one" or "two" tag
+$query->find('tagged', ['slug' => 'one,two']);
+
+// Records that have both "one" and "two" tag
+$query->find('tagged', ['slug' => 'one+two']);
+```
+
+For this to be used inside Search plugin, you would usually generate URLs like this:
+```php
+$this->Html->link('Title', ['?' => ['tag'=> 'one,two']]);
+$this->Html->link('Title', ['?' => ['tag'=> 'one+two']]);
+```
+Inside the URLs the special chars will automatically be URLencoded.
+
 ##### Finding records without tags
 You can use the untagged finder here inside the search callback.
 For this the `tag_count` field (and check for 0) is the quickest and easiest. It will otherwise
@@ -245,15 +263,21 @@ The most important ones are:
 
 - `'taggedCounter'`: Set to false if you don't need a counter cache field in your tagged table.
 - `'strategy'`: `'string'`/`'array'`
-- `'delimiter'` - Separating the tags, e.g.: `','`
+- `'delimiter'` - Separating the tags in input elements or as string list, e.g.: `','`
 - `'namespace'` - `'string'` to use for internal namespace column. Do not use together with separator if you want to keep it internal. Otherwise it will become the default namespace and visible.
 - `'separator'`: For namespace prefix, e.g.: `':'`. With this set the namespace will be parsed from the tag.
+- `'andSeparator'` - Allows AND filtering, e.g.: `'+'` or `'&'`
+- `'orSeparator'` - Allows OR filtering, e.g.: `','` or `'|'`
 
 You can set them globally using Configure and the `Tags` config key.
 
 If you need also to pass options to the slug behavior, use an array config for it:
 ```php
-'slugBehavior' => ['Tools.Slugged' => ['mode' => [Text::class, 'slug'], ...],
+'slugBehavior' => [
+    'Tools.Slugged' => [
+        'mode' => [Text::class, 'slug'],
+        ...
+],
 ```
 
 ### Custom slugging

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -609,6 +609,51 @@ class TagBehaviorTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testFinderTaggedWithOr() {
+		$entity = $this->Table->newEntity([
+			'name' => 'Heavy',
+			'tag_list' => 'color,weight',
+		]);
+		$this->Table->saveOrFail($entity);
+
+		$result = $this->Table->Tags->find('all')->where(['slug IN' => ['color', 'weight']])->distinct()->toArray();
+		$this->assertCount(2, $result);
+
+		$result = $this->Table->Tagged->find('all')->where(['tag_id IN' => Hash::extract($result, '{n}.id')])->toArray();
+		$this->assertCount(4, $result);
+
+		$result = $this->Table->find('tagged', ['slug' => 'color,weight'])->orderAsc($this->Table->aliasField('name'))->toArray();
+		$this->assertCount(3, $result);
+
+		$expected = ['Blue', 'Heavy', 'Red'];
+		$this->assertSame($expected, Hash::extract($result, '{n}.name'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFinderTaggedWithAnd() {
+		$entity = $this->Table->newEntity([
+			'name' => 'Heavy',
+			'tag_list' => 'color,weight',
+		]);
+		$this->Table->saveOrFail($entity);
+
+		$result = $this->Table->Tags->find('all')->where(['slug IN' => ['color', 'weight']])->distinct()->toArray();
+		$this->assertCount(2, $result);
+
+		$result = $this->Table->Tagged->find('all')->where(['tag_id IN' => Hash::extract($result, '{n}.id')])->toArray();
+		$this->assertCount(4, $result);
+
+		$result = $this->Table->find('tagged', ['slug' => 'color+weight'])->orderAsc($this->Table->aliasField('name'))->toArray();
+
+		$expected = ['Heavy'];
+		$this->assertSame($expected, Hash::extract($result, '{n}.name'));
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testFinderTaggedLabel() {
 		$this->Table->behaviors()->Tag->setConfig('finderField', 'label');
 
@@ -630,7 +675,7 @@ class TagBehaviorTest extends TestCase {
 	public function testFinderTaggedArray() {
 		$entity = $this->Table->newEntity([
 			'name' => 'Shiny',
-			'tag_list' => 'Beautiful',
+			'tag_list' => 'Color,Beautiful',
 		]);
 		$this->Table->saveOrFail($entity);
 


### PR DESCRIPTION
WIP

See https://sandbox.dereuromark.de/sandbox/tags/search
and URLS
- ?tag=x,y
- ?tag=x+y

Note: The actual concat characters would be urlescaped of course (I am referring to the resulting strings inside the application here for readability).

Meaning:
- x,y: find any record with either one of those tags
- x+y: find any record that has both of those tags

Restriction: We don't allow mixing OR/AND to keep things simple.

The idea is to add basic/simple ORM snippets for each case to allow filtering by multiple tags instead of status quo of just one (or none).
What are the best strategies here when using the Cake ORM? To avoid any custom SQL and issues with DB agnostic querying.