### PR TITLE
Add modern admin backend with Bootstrap 5

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -7,5 +7,9 @@ return [
 		'strategy' => 'string', // string or array
 		'delimiter' => ',', // separating the tags
 		'separator' => null, // for namespace prefix, e.g.: ':'
+
+		// Admin dashboard options
+		'standalone' => false, // Set to true for isolated admin that doesn't depend on the host app
+		'adminLayout' => null, // null = plugin layout, false = app layout, string = custom layout
 	],
 ];

--- a/config/routes.php
+++ b/config/routes.php
@@ -7,28 +7,24 @@ use Cake\Routing\RouteBuilder;
 /**
  * @var \Cake\Routing\RouteBuilder $routes
  */
-$routes->plugin(
-	'Tags',
-	['path' => '/tags'],
-	function (RouteBuilder $routes): void {
-		$routes->prefix('Admin', function (RouteBuilder $routes): void {
-			$routes->setRouteClass(DashedRoute::class);
+$routes->prefix('Admin', function (RouteBuilder $routes): void {
+	$routes->plugin('Tags', ['path' => '/tags'], function (RouteBuilder $routes): void {
+		$routes->setRouteClass(DashedRoute::class);
 
-			// Dashboard
-			$routes->connect('/', ['controller' => 'TagsDashboard', 'action' => 'index']);
+		// Dashboard
+		$routes->connect('/', ['controller' => 'TagsDashboard', 'action' => 'index']);
 
-			// Tags CRUD
-			$routes->connect('/tags', ['controller' => 'Tags', 'action' => 'index']);
-			$routes->connect('/tags/add', ['controller' => 'Tags', 'action' => 'add']);
-			$routes->connect('/tags/edit/{id}', ['controller' => 'Tags', 'action' => 'edit'], ['pass' => ['id']]);
-			$routes->connect('/tags/view/{id}', ['controller' => 'Tags', 'action' => 'view'], ['pass' => ['id']]);
-			$routes->connect('/tags/delete/{id}', ['controller' => 'Tags', 'action' => 'delete'], ['pass' => ['id']]);
+		// Tags CRUD
+		$routes->connect('/tags', ['controller' => 'Tags', 'action' => 'index']);
+		$routes->connect('/tags/add', ['controller' => 'Tags', 'action' => 'add']);
+		$routes->connect('/tags/edit/{id}', ['controller' => 'Tags', 'action' => 'edit'], ['pass' => ['id']]);
+		$routes->connect('/tags/view/{id}', ['controller' => 'Tags', 'action' => 'view'], ['pass' => ['id']]);
+		$routes->connect('/tags/delete/{id}', ['controller' => 'Tags', 'action' => 'delete'], ['pass' => ['id']]);
 
-			// Merge
-			$routes->connect('/tags/merge', ['controller' => 'Tags', 'action' => 'merge']);
-			$routes->connect('/tags/merge-preview', ['controller' => 'Tags', 'action' => 'mergePreview']);
+		// Merge
+		$routes->connect('/tags/merge', ['controller' => 'Tags', 'action' => 'merge']);
+		$routes->connect('/tags/merge-preview', ['controller' => 'Tags', 'action' => 'mergePreview']);
 
-			$routes->fallbacks(DashedRoute::class);
-		});
-	},
-);
+		$routes->fallbacks(DashedRoute::class);
+	});
+});

--- a/config/routes.php
+++ b/config/routes.php
@@ -24,6 +24,7 @@ $routes->prefix('Admin', function (RouteBuilder $routes): void {
 
 		// Maintenance
 		$routes->connect('/tags/duplicates', ['controller' => 'Tags', 'action' => 'duplicates']);
+		$routes->connect('/tags/orphaned', ['controller' => 'Tags', 'action' => 'orphaned']);
 		$routes->connect('/tags/delete-orphaned', ['controller' => 'Tags', 'action' => 'deleteOrphaned']);
 		$routes->connect('/tags/recalculate-counters', ['controller' => 'Tags', 'action' => 'recalculateCounters']);
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -25,6 +25,15 @@ $routes->prefix('Admin', function (RouteBuilder $routes): void {
 		$routes->connect('/tags/merge', ['controller' => 'Tags', 'action' => 'merge']);
 		$routes->connect('/tags/merge-preview', ['controller' => 'Tags', 'action' => 'mergePreview']);
 
+		// Maintenance
+		$routes->connect('/tags/duplicates', ['controller' => 'Tags', 'action' => 'duplicates']);
+		$routes->connect('/tags/delete-orphaned', ['controller' => 'Tags', 'action' => 'deleteOrphaned']);
+		$routes->connect('/tags/recalculate-counters', ['controller' => 'Tags', 'action' => 'recalculateCounters']);
+
+		// Tools
+		$routes->connect('/tags/export', ['controller' => 'Tags', 'action' => 'export']);
+		$routes->connect('/tags/change-namespace', ['controller' => 'Tags', 'action' => 'changeNamespace']);
+
 		$routes->fallbacks(DashedRoute::class);
 	});
 });

--- a/config/routes.php
+++ b/config/routes.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 
-/**
- * @var \Cake\Routing\RouteBuilder $routes
- */
 $routes->prefix('Admin', function (RouteBuilder $routes): void {
 	$routes->plugin('Tags', ['path' => '/tags'], function (RouteBuilder $routes): void {
 		$routes->setRouteClass(DashedRoute::class);

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\RouteBuilder;
+
+/**
+ * @var \Cake\Routing\RouteBuilder $routes
+ */
+$routes->plugin(
+	'Tags',
+	['path' => '/tags'],
+	function (RouteBuilder $routes): void {
+		$routes->prefix('Admin', function (RouteBuilder $routes): void {
+			$routes->setRouteClass(DashedRoute::class);
+
+			// Dashboard
+			$routes->connect('/', ['controller' => 'TagsDashboard', 'action' => 'index']);
+
+			// Tags CRUD
+			$routes->connect('/tags', ['controller' => 'Tags', 'action' => 'index']);
+			$routes->connect('/tags/add', ['controller' => 'Tags', 'action' => 'add']);
+			$routes->connect('/tags/edit/{id}', ['controller' => 'Tags', 'action' => 'edit'], ['pass' => ['id']]);
+			$routes->connect('/tags/view/{id}', ['controller' => 'Tags', 'action' => 'view'], ['pass' => ['id']]);
+			$routes->connect('/tags/delete/{id}', ['controller' => 'Tags', 'action' => 'delete'], ['pass' => ['id']]);
+
+			// Merge
+			$routes->connect('/tags/merge', ['controller' => 'Tags', 'action' => 'merge']);
+			$routes->connect('/tags/merge-preview', ['controller' => 'Tags', 'action' => 'mergePreview']);
+
+			$routes->fallbacks(DashedRoute::class);
+		});
+	},
+);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,10 +2,13 @@ parameters:
 	level: 8
 	paths:
 		- src/
+	scanDirectories:
+		- tests/test_app/src/
 	bootstrapFiles:
 		- tests/bootstrap.php
 	ignoreErrors:
 		- identifier: missingType.iterableValue
 		- identifier: missingType.generics
 		- '#PHPDoc tag @property for property .+TaggedTable\:\:\$.+ contains unresolvable type.#'
+		- '#PHPDoc tag @property for property .+TagsTable\:\:\$.+ contains unresolvable type.#'
 		- '#Access to an undefined property .+::\$.+.#'

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Controller\Admin;
+
+use Cake\Core\Plugin;
+
+trait LoadHelperTrait {
+
+	/**
+	 * @return void
+	 */
+	protected function loadHelpers(): void {
+		$helpers = [];
+
+		// Time helper: prefer Tools, fallback to core
+		if (Plugin::isLoaded('Tools')) {
+			$helpers[] = 'Tools.Time';
+			$helpers[] = 'Tools.Text';
+			$helpers[] = 'Tools.Format';
+		} else {
+			$helpers[] = 'Time';
+			$helpers[] = 'Text';
+		}
+
+		$helpers[] = 'Tags.Tag';
+
+		$this->viewBuilder()->addHelpers($helpers);
+	}
+
+}

--- a/src/Controller/Admin/TagsAppController.php
+++ b/src/Controller/Admin/TagsAppController.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Controller\Admin;
+
+use App\Controller\AppController;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+
+/**
+ * TagsAppController
+ *
+ * Base controller for Tags admin.
+ *
+ * By default, extends AppController to inherit app authentication, components, and configuration.
+ * Set `Tags.standalone` to `true` for an isolated admin that doesn't depend on the host app.
+ */
+class TagsAppController extends AppController {
+
+	use LoadHelperTrait;
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void {
+		if (Configure::read('Tags.standalone')) {
+			// Standalone mode: skip app's AppController, initialize independently
+			Controller::initialize();
+			$this->loadComponent('Flash');
+		} else {
+			// Default: inherit app's full controller setup
+			parent::initialize();
+		}
+
+		$this->loadHelpers();
+
+		// Layout configuration:
+		// - null (default): Uses 'Tags.tags' isolated Bootstrap 5 layout
+		// - false: Disables plugin layout, uses app's default layout
+		// - string: Uses specified layout (e.g., 'Tags.tags' or custom)
+		$layout = Configure::read('Tags.adminLayout');
+		if ($layout !== false) {
+			$this->viewBuilder()->setLayout($layout ?: 'Tags.tags');
+		}
+	}
+
+}

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tags\Controller\Admin;
 
 use Cake\Http\Response;
+use RuntimeException;
 
 /**
  * Tags Controller
@@ -359,7 +360,7 @@ class TagsController extends TagsAppController {
 		// Build CSV content
 		$output = fopen('php://temp', 'r+');
 		if ($output === false) {
-			throw new \RuntimeException('Failed to open temporary file for CSV export');
+			throw new RuntimeException('Failed to open temporary file for CSV export');
 		}
 
 		// Header row

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -29,8 +29,8 @@ class TagsController extends TagsAppController {
 
 		// Filter by namespace
 		$namespace = $this->request->getQuery('namespace');
-		if ($namespace !== null) {
-			if ($namespace === '') {
+		if ($namespace !== null && $namespace !== '') {
+			if ($namespace === '__none__') {
 				$query->where(['namespace IS' => null]);
 			} else {
 				$query->where(['namespace' => $namespace]);
@@ -297,6 +297,23 @@ class TagsController extends TagsAppController {
 	}
 
 	/**
+	 * Orphaned tags action - show tags with zero usage.
+	 *
+	 * @return void
+	 */
+	public function orphaned(): void {
+		$query = $this->Tags->find()
+			->where(['counter' => 0])
+			->orderByAsc('namespace')
+			->orderByAsc('label');
+
+		$orphanedTags = $this->paginate($query);
+		$orphanedCount = $this->Tags->find()->where(['counter' => 0])->count();
+
+		$this->set(compact('orphanedTags', 'orphanedCount'));
+	}
+
+	/**
 	 * Delete orphaned tags action.
 	 *
 	 * @return \Cake\Http\Response|null
@@ -312,7 +329,7 @@ class TagsController extends TagsAppController {
 			$this->Flash->info(__d('tags', 'No orphaned tags found.'));
 		}
 
-		return $this->redirect(['controller' => 'TagsDashboard', 'action' => 'index']);
+		return $this->redirect(['action' => 'orphaned']);
 	}
 
 	/**

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -284,4 +284,167 @@ class TagsController extends TagsAppController {
 		return null;
 	}
 
+	/**
+	 * Duplicates action - show potential duplicate tags.
+	 *
+	 * @return void
+	 */
+	public function duplicates(): void {
+		$duplicateGroups = $this->Tags->findDuplicates();
+
+		$this->set(compact('duplicateGroups'));
+	}
+
+	/**
+	 * Delete orphaned tags action.
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function deleteOrphaned(): ?Response {
+		$this->request->allowMethod(['post', 'delete']);
+
+		$count = $this->Tags->deleteOrphaned();
+
+		if ($count > 0) {
+			$this->Flash->success(__d('tags', '{0} orphaned tags have been deleted.', $count));
+		} else {
+			$this->Flash->info(__d('tags', 'No orphaned tags found.'));
+		}
+
+		return $this->redirect(['controller' => 'TagsDashboard', 'action' => 'index']);
+	}
+
+	/**
+	 * Recalculate counters action.
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function recalculateCounters(): ?Response {
+		$this->request->allowMethod(['post']);
+
+		$count = $this->Tags->recalculateCounters();
+
+		if ($count > 0) {
+			$this->Flash->success(__d('tags', '{0} tag counters have been updated.', $count));
+		} else {
+			$this->Flash->info(__d('tags', 'All counters are already correct.'));
+		}
+
+		return $this->redirect(['controller' => 'TagsDashboard', 'action' => 'index']);
+	}
+
+	/**
+	 * Export tags to CSV.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function export(): Response {
+		$namespace = $this->request->getQuery('namespace');
+
+		$query = $this->Tags->find()
+			->orderByAsc('namespace')
+			->orderByAsc('label');
+
+		if ($namespace !== null) {
+			if ($namespace === '') {
+				$query->where(['namespace IS' => null]);
+			} else {
+				$query->where(['namespace' => $namespace]);
+			}
+		}
+
+		/** @var array<\Tags\Model\Entity\Tag> $tags */
+		$tags = $query->all()->toArray();
+
+		// Build CSV content
+		$output = fopen('php://temp', 'r+');
+		if ($output === false) {
+			throw new \RuntimeException('Failed to open temporary file for CSV export');
+		}
+
+		// Header row
+		fputcsv($output, ['id', 'namespace', 'slug', 'label', 'color', 'counter', 'created', 'modified']);
+
+		// Data rows
+		foreach ($tags as $tag) {
+			fputcsv($output, [
+				$tag->id,
+				$tag->namespace ?? '',
+				$tag->slug,
+				$tag->label,
+				$tag->color ?? '',
+				$tag->counter,
+				$tag->created->format('Y-m-d H:i:s'),
+				$tag->modified->format('Y-m-d H:i:s'),
+			]);
+		}
+
+		rewind($output);
+		$csv = stream_get_contents($output);
+		fclose($output);
+
+		$filename = 'tags-export-' . date('Y-m-d-His') . '.csv';
+
+		$response = $this->response
+			->withType('csv')
+			->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+			->withStringBody($csv ?: '');
+
+		return $response;
+	}
+
+	/**
+	 * Change namespace for tags.
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function changeNamespace(): ?Response {
+		// Get unique namespaces
+		$namespaces = $this->Tags->find()
+			->select(['namespace'])
+			->distinct()
+			->orderByAsc('namespace')
+			->all()
+			->extract('namespace')
+			->toArray();
+
+		if ($this->request->is('post')) {
+			$fromNamespace = $this->request->getData('from_namespace');
+			$toNamespace = $this->request->getData('to_namespace');
+
+			// Handle empty string as null
+			if ($fromNamespace === '') {
+				$fromNamespace = null;
+			}
+			if ($toNamespace === '') {
+				$toNamespace = null;
+			}
+
+			if ($fromNamespace === $toNamespace) {
+				$this->Flash->error(__d('tags', 'Source and target namespaces must be different.'));
+
+				$this->set(compact('namespaces'));
+
+				return null;
+			}
+
+			$count = $this->Tags->updateAll(
+				['namespace' => $toNamespace],
+				['namespace IS' => $fromNamespace],
+			);
+
+			if ($count > 0) {
+				$this->Flash->success(__d('tags', '{0} tags have been moved to the new namespace.', $count));
+
+				return $this->redirect(['action' => 'changeNamespace']);
+			}
+
+			$this->Flash->info(__d('tags', 'No tags found in the source namespace.'));
+		}
+
+		$this->set(compact('namespaces'));
+
+		return null;
+	}
+
 }

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -1,0 +1,287 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Controller\Admin;
+
+use Cake\Http\Response;
+
+/**
+ * Tags Controller
+ *
+ * @property \Tags\Model\Table\TagsTable $Tags
+ * @property \Tags\Model\Table\TaggedTable $Tagged
+ */
+class TagsController extends TagsAppController {
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $defaultTable = 'Tags.Tags';
+
+	/**
+	 * Index action - list all tags.
+	 *
+	 * @return void
+	 */
+	public function index(): void {
+		$query = $this->Tags->find();
+
+		// Filter by namespace
+		$namespace = $this->request->getQuery('namespace');
+		if ($namespace !== null) {
+			if ($namespace === '') {
+				$query->where(['namespace IS' => null]);
+			} else {
+				$query->where(['namespace' => $namespace]);
+			}
+		}
+
+		// Filter orphaned tags (counter = 0)
+		if ($this->request->getQuery('orphaned')) {
+			$query->where(['counter' => 0]);
+		}
+
+		// Search by label/slug
+		$search = $this->request->getQuery('search');
+		if ($search) {
+			$query->where([
+				'OR' => [
+					'label LIKE' => '%' . $search . '%',
+					'slug LIKE' => '%' . $search . '%',
+				],
+			]);
+		}
+
+		$query->orderByAsc('namespace')->orderByAsc('label');
+
+		$tags = $this->paginate($query);
+
+		// Get unique namespaces for filter
+		$namespaces = $this->Tags->find()
+			->select(['namespace'])
+			->distinct()
+			->orderByAsc('namespace')
+			->all()
+			->extract('namespace')
+			->toArray();
+
+		$this->set(compact('tags', 'namespaces', 'namespace', 'search'));
+	}
+
+	/**
+	 * View action - view a single tag.
+	 *
+	 * @param string|null $id Tag id.
+	 * @return void
+	 */
+	public function view(?string $id = null): void {
+		$tag = $this->Tags->get($id);
+
+		// Get recent usages
+		$taggedTable = $this->fetchTable('Tags.Tagged');
+		$usages = $taggedTable->find()
+			->where(['tag_id' => $id])
+			->orderByDesc('created')
+			->limit(20)
+			->all()
+			->toArray();
+
+		// Get usage by model
+		$usagesByModel = $taggedTable->find()
+			->select([
+				'fk_model',
+				'count' => $taggedTable->find()->func()->count('*'),
+			])
+			->where(['tag_id' => $id])
+			->groupBy('fk_model')
+			->disableHydration()
+			->all()
+			->toArray();
+
+		$this->set(compact('tag', 'usages', 'usagesByModel'));
+	}
+
+	/**
+	 * Add action - create a new tag.
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function add(): ?Response {
+		$tag = $this->Tags->newEmptyEntity();
+
+		if ($this->request->is('post')) {
+			$tag = $this->Tags->patchEntity($tag, $this->request->getData());
+			if ($this->Tags->save($tag)) {
+				$this->Flash->success(__d('tags', 'The tag has been saved.'));
+
+				return $this->redirect(['action' => 'index']);
+			}
+			$this->Flash->error(__d('tags', 'The tag could not be saved. Please try again.'));
+		}
+
+		// Get unique namespaces for suggestions
+		$namespaces = $this->Tags->find()
+			->select(['namespace'])
+			->distinct()
+			->where(['namespace IS NOT' => null])
+			->orderByAsc('namespace')
+			->all()
+			->extract('namespace')
+			->toArray();
+
+		$this->set(compact('tag', 'namespaces'));
+
+		return null;
+	}
+
+	/**
+	 * Edit action - edit an existing tag.
+	 *
+	 * @param string|null $id Tag id.
+	 * @return \Cake\Http\Response|null
+	 */
+	public function edit(?string $id = null): ?Response {
+		$tag = $this->Tags->get($id);
+
+		if ($this->request->is(['patch', 'post', 'put'])) {
+			$tag = $this->Tags->patchEntity($tag, $this->request->getData());
+			if ($this->Tags->save($tag)) {
+				$this->Flash->success(__d('tags', 'The tag has been saved.'));
+
+				return $this->redirect(['action' => 'index']);
+			}
+			$this->Flash->error(__d('tags', 'The tag could not be saved. Please try again.'));
+		}
+
+		// Get unique namespaces for suggestions
+		$namespaces = $this->Tags->find()
+			->select(['namespace'])
+			->distinct()
+			->where(['namespace IS NOT' => null])
+			->orderByAsc('namespace')
+			->all()
+			->extract('namespace')
+			->toArray();
+
+		$this->set(compact('tag', 'namespaces'));
+
+		return null;
+	}
+
+	/**
+	 * Delete action - delete a tag.
+	 *
+	 * @param string|null $id Tag id.
+	 * @return \Cake\Http\Response|null
+	 */
+	public function delete(?string $id = null): ?Response {
+		$this->request->allowMethod(['post', 'delete']);
+
+		$tag = $this->Tags->get($id);
+
+		if ($this->Tags->delete($tag)) {
+			$this->Flash->success(__d('tags', 'The tag has been deleted.'));
+		} else {
+			$this->Flash->error(__d('tags', 'The tag could not be deleted. Please try again.'));
+		}
+
+		return $this->redirect(['action' => 'index']);
+	}
+
+	/**
+	 * Merge action - select tags to merge.
+	 *
+	 * @return void
+	 */
+	public function merge(): void {
+		// Get tags grouped by namespace for dropdowns
+		/** @var array<\Tags\Model\Entity\Tag> $tags */
+		$tags = $this->Tags->find()
+			->orderByAsc('namespace')
+			->orderByAsc('label')
+			->all()
+			->toArray();
+
+		// Group by namespace
+		$tagsByNamespace = [];
+		foreach ($tags as $tag) {
+			$ns = $tag->namespace ?: '';
+			if (!isset($tagsByNamespace[$ns])) {
+				$tagsByNamespace[$ns] = [];
+			}
+			$tagsByNamespace[$ns][] = $tag;
+		}
+
+		$this->set(compact('tags', 'tagsByNamespace'));
+	}
+
+	/**
+	 * Merge preview action - show preview and execute merge.
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function mergePreview(): ?Response {
+		$sourceId = $this->request->getQuery('source') ?: $this->request->getData('source');
+		$targetId = $this->request->getQuery('target') ?: $this->request->getData('target');
+
+		if (!$sourceId || !$targetId) {
+			$this->Flash->error(__d('tags', 'Please select both source and target tags.'));
+
+			return $this->redirect(['action' => 'merge']);
+		}
+
+		if ($sourceId === $targetId) {
+			$this->Flash->error(__d('tags', 'Source and target tags must be different.'));
+
+			return $this->redirect(['action' => 'merge']);
+		}
+
+		$sourceTag = $this->Tags->get($sourceId);
+		$targetTag = $this->Tags->get($targetId);
+
+		// Check namespace match
+		if ($sourceTag->namespace !== $targetTag->namespace) {
+			$this->Flash->error(__d('tags', 'Tags must be in the same namespace to merge.'));
+
+			return $this->redirect(['action' => 'merge']);
+		}
+
+		$taggedTable = $this->fetchTable('Tags.Tagged');
+
+		// Count items that will be re-tagged
+		$itemsToRetag = $taggedTable->find()
+			->where(['tag_id' => $sourceId])
+			->count();
+
+		// Count duplicates (items that have both tags)
+		$duplicates = $taggedTable->find()
+			->where(['tag_id' => $sourceId])
+			->innerJoin(
+				['t2' => 'tags_tagged'],
+				[
+					't2.tag_id' => $targetId,
+					't2.fk_id = Tagged.fk_id',
+					't2.fk_model = Tagged.fk_model',
+				],
+			)
+			->count();
+
+		// Execute merge on POST
+		if ($this->request->is('post') && $this->request->getData('confirm')) {
+			$merged = $this->Tags->merge((int)$sourceId, (int)$targetId);
+
+			if ($merged) {
+				$this->Flash->success(__d('tags', 'Tags have been merged successfully. {0} items were re-tagged.', $itemsToRetag - $duplicates));
+
+				return $this->redirect(['action' => 'index']);
+			}
+
+			$this->Flash->error(__d('tags', 'The tags could not be merged. Please try again.'));
+		}
+
+		$this->set(compact('sourceTag', 'targetTag', 'itemsToRetag', 'duplicates'));
+
+		return null;
+	}
+
+}

--- a/src/Controller/Admin/TagsDashboardController.php
+++ b/src/Controller/Admin/TagsDashboardController.php
@@ -22,7 +22,9 @@ class TagsDashboardController extends TagsAppController {
 	 * @return void
 	 */
 	public function index(): void {
+		/** @var \Tags\Model\Table\TagsTable $tagsTable */
 		$tagsTable = $this->fetchTable('Tags.Tags');
+		/** @var \Tags\Model\Table\TaggedTable $taggedTable */
 		$taggedTable = $this->fetchTable('Tags.Tagged');
 
 		// Total tags count
@@ -52,6 +54,10 @@ class TagsDashboardController extends TagsAppController {
 			->where(['counter' => 0])
 			->count();
 
+		// Potential duplicates
+		$duplicateGroups = $tagsTable->findDuplicates();
+		$duplicateCount = count($duplicateGroups);
+
 		// Recently created tags (last 10)
 		$recentTags = $tagsTable->find()
 			->orderByDesc('created')
@@ -78,6 +84,7 @@ class TagsDashboardController extends TagsAppController {
 			'namespaces',
 			'mostUsedTags',
 			'orphanedCount',
+			'duplicateCount',
 			'recentTags',
 			'totalTagged',
 			'models',

--- a/src/Controller/Admin/TagsDashboardController.php
+++ b/src/Controller/Admin/TagsDashboardController.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Controller\Admin;
+
+/**
+ * TagsDashboard Controller
+ *
+ * @property \Tags\Model\Table\TagsTable $Tags
+ * @property \Tags\Model\Table\TaggedTable $Tagged
+ */
+class TagsDashboardController extends TagsAppController {
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $defaultTable = 'Tags.Tags';
+
+	/**
+	 * Dashboard index action.
+	 *
+	 * @return void
+	 */
+	public function index(): void {
+		$tagsTable = $this->fetchTable('Tags.Tags');
+		$taggedTable = $this->fetchTable('Tags.Tagged');
+
+		// Total tags count
+		$totalTags = $tagsTable->find()->count();
+
+		// Tags by namespace
+		$namespaces = $tagsTable->find()
+			->select([
+				'namespace',
+				'count' => $tagsTable->find()->func()->count('*'),
+			])
+			->groupBy('namespace')
+			->disableHydration()
+			->all()
+			->toArray();
+
+		// Most used tags (top 10)
+		$mostUsedTags = $tagsTable->find()
+			->where(['counter >' => 0])
+			->orderByDesc('counter')
+			->limit(10)
+			->all()
+			->toArray();
+
+		// Orphaned tags (never used or counter = 0)
+		$orphanedCount = $tagsTable->find()
+			->where(['counter' => 0])
+			->count();
+
+		// Recently created tags (last 10)
+		$recentTags = $tagsTable->find()
+			->orderByDesc('created')
+			->limit(10)
+			->all()
+			->toArray();
+
+		// Total tagged associations
+		$totalTagged = $taggedTable->find()->count();
+
+		// Models using tags
+		$models = $taggedTable->find()
+			->select([
+				'fk_model',
+				'count' => $taggedTable->find()->func()->count('*'),
+			])
+			->groupBy('fk_model')
+			->disableHydration()
+			->all()
+			->toArray();
+
+		$this->set(compact(
+			'totalTags',
+			'namespaces',
+			'mostUsedTags',
+			'orphanedCount',
+			'recentTags',
+			'totalTagged',
+			'models',
+		));
+	}
+
+}

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -11,6 +11,8 @@ use Cake\Validation\Validator;
 use RuntimeException;
 
 /**
+ * @property \Tags\Model\Table\TaggedTable&\Cake\ORM\Association\HasMany $Tagged
+ *
  * @method \Tags\Model\Entity\Tag get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Tags\Model\Entity\Tag newEntity(array $data, array $options = [])
  * @method array<\Tags\Model\Entity\Tag> newEntities(array $data, array $options = [])
@@ -40,6 +42,12 @@ class TagsTable extends Table {
 		$this->setTable('tags_tags');
 		$this->setDisplayField('label'); // Change to name?
 		$this->addBehavior('Timestamp');
+
+		$this->hasMany('Tagged', [
+			'className' => 'Tags.Tagged',
+			'foreignKey' => 'tag_id',
+			'dependent' => true,
+		]);
 	}
 
 	/**
@@ -111,6 +119,69 @@ class TagsTable extends Table {
 		}
 
 		return mb_strtolower(Text::slug($label));
+	}
+
+	/**
+	 * Merge one tag into another.
+	 *
+	 * All associations from the source tag will be moved to the target tag.
+	 * Duplicate associations (where an item already has both tags) will be removed.
+	 * The source tag will be deleted after the merge.
+	 *
+	 * @param int $sourceId The ID of the tag to merge from (will be deleted).
+	 * @param int $targetId The ID of the tag to merge into (will remain).
+	 * @return bool True on success, false on failure.
+	 */
+	public function merge(int $sourceId, int $targetId): bool {
+		$sourceTag = $this->get($sourceId);
+		$targetTag = $this->get($targetId);
+
+		// Verify same namespace
+		if ($sourceTag->namespace !== $targetTag->namespace) {
+			return false;
+		}
+
+		$taggedTable = $this->getAssociation('Tagged')->getTarget();
+		$connection = $this->getConnection();
+
+		return $connection->transactional(function () use ($taggedTable, $sourceId, $targetId, $sourceTag, $targetTag) {
+			// Find IDs of duplicate associations (items that already have the target tag)
+			$duplicateIds = $taggedTable->find()
+				->select(['Tagged.id'])
+				->innerJoin(
+					['t2' => 'tags_tagged'],
+					[
+						't2.tag_id' => $targetId,
+						't2.fk_id = Tagged.fk_id',
+						't2.fk_model = Tagged.fk_model',
+					],
+				)
+				->where(['Tagged.tag_id' => $sourceId])
+				->all()
+				->extract('id')
+				->toArray();
+
+			// Delete duplicates
+			if ($duplicateIds) {
+				$taggedTable->deleteAll(['id IN' => $duplicateIds]);
+			}
+
+			// Move remaining associations from source to target
+			$taggedTable->updateAll(
+				['tag_id' => $targetId],
+				['tag_id' => $sourceId],
+			);
+
+			// Update target tag counter
+			$newCount = $taggedTable->find()
+				->where(['tag_id' => $targetId])
+				->count();
+			$targetTag->counter = $newCount;
+			$this->saveOrFail($targetTag);
+
+			// Delete source tag
+			return $this->delete($sourceTag);
+		});
 	}
 
 }

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -122,6 +122,144 @@ class TagsTable extends Table {
 	}
 
 	/**
+	 * Find potential duplicate tags based on similar slugs.
+	 *
+	 * Detects duplicates by finding tags where one slug is a prefix of another,
+	 * or tags that differ only by common suffixes (s, es, ing, ed).
+	 *
+	 * @param string|null $namespace Optional namespace to filter by.
+	 * @return array<array<\Tags\Model\Entity\Tag>> Groups of potentially duplicate tags.
+	 */
+	public function findDuplicates(?string $namespace = null): array {
+		$query = $this->find()
+			->orderByAsc('namespace')
+			->orderByAsc('slug');
+
+		if ($namespace !== null) {
+			$query->where(['namespace' => $namespace ?: null]);
+		}
+
+		/** @var array<\Tags\Model\Entity\Tag> $tags */
+		$tags = $query->all()->toArray();
+
+		$duplicates = [];
+		$processed = [];
+
+		foreach ($tags as $i => $tag) {
+			if (isset($processed[$tag->id])) {
+				continue;
+			}
+
+			$group = [$tag];
+			$baseSlug = $this->normalizeSlug($tag->slug);
+
+			foreach ($tags as $j => $otherTag) {
+				if ($i === $j || isset($processed[$otherTag->id])) {
+					continue;
+				}
+
+				// Must be same namespace
+				if ($tag->namespace !== $otherTag->namespace) {
+					continue;
+				}
+
+				$otherBaseSlug = $this->normalizeSlug($otherTag->slug);
+
+				// Check if slugs are similar
+				if ($baseSlug === $otherBaseSlug ||
+					str_starts_with($otherBaseSlug, $baseSlug) ||
+					str_starts_with($baseSlug, $otherBaseSlug) ||
+					levenshtein($baseSlug, $otherBaseSlug) <= 2
+				) {
+					$group[] = $otherTag;
+					$processed[$otherTag->id] = true;
+				}
+			}
+
+			if (count($group) > 1) {
+				$duplicates[] = $group;
+				$processed[$tag->id] = true;
+			}
+		}
+
+		return $duplicates;
+	}
+
+	/**
+	 * Normalize a slug for duplicate comparison.
+	 *
+	 * Removes common suffixes like pluralization.
+	 *
+	 * @param string $slug The slug to normalize.
+	 * @return string The normalized slug.
+	 */
+	protected function normalizeSlug(string $slug): string {
+		// Remove common suffixes
+		$suffixes = ['ies', 'es', 's', 'ing', 'ed'];
+		foreach ($suffixes as $suffix) {
+			if (str_ends_with($slug, $suffix) && strlen($slug) > strlen($suffix) + 2) {
+				return substr($slug, 0, -strlen($suffix));
+			}
+		}
+
+		return $slug;
+	}
+
+	/**
+	 * Delete all orphaned tags (counter = 0).
+	 *
+	 * @param string|null $namespace Optional namespace to filter by.
+	 * @return int Number of deleted tags.
+	 */
+	public function deleteOrphaned(?string $namespace = null): int {
+		$conditions = ['counter' => 0];
+
+		if ($namespace !== null) {
+			$conditions['namespace'] = $namespace ?: null;
+		}
+
+		return $this->deleteAll($conditions);
+	}
+
+	/**
+	 * Recalculate counter cache for all tags.
+	 *
+	 * Useful when counters get out of sync.
+	 *
+	 * @return int Number of tags updated.
+	 */
+	public function recalculateCounters(): int {
+		$taggedTable = $this->getAssociation('Tagged')->getTarget();
+		$updated = 0;
+
+		// Get actual counts from tagged table
+		$counts = $taggedTable->find()
+			->select([
+				'tag_id',
+				'count' => $taggedTable->find()->func()->count('*'),
+			])
+			->groupBy('tag_id')
+			->disableHydration()
+			->all()
+			->combine('tag_id', 'count')
+			->toArray();
+
+		// Update all tags
+		/** @var array<\Tags\Model\Entity\Tag> $tags */
+		$tags = $this->find()->all()->toArray();
+		foreach ($tags as $tag) {
+			$newCount = $counts[$tag->id] ?? 0;
+			if ($tag->counter !== $newCount) {
+				$tag->counter = $newCount;
+				$this->save($tag);
+				$updated++;
+			}
+		}
+
+		return $updated;
+	}
+
+	/**
 	 * Merge one tag into another.
 	 *
 	 * All associations from the source tag will be moved to the target tag.

--- a/src/TagsPlugin.php
+++ b/src/TagsPlugin.php
@@ -24,6 +24,6 @@ class TagsPlugin extends BasePlugin {
 	/**
 	 * @var bool
 	 */
-	protected bool $routesEnabled = false;
+	protected bool $routesEnabled = true;
 
 }

--- a/templates/Admin/Tags/add.php
+++ b/templates/Admin/Tags/add.php
@@ -86,7 +86,7 @@
 				'escapeTitle' => false,
 			]) ?>
 			<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
-				<?= __d('tags', 'Cancel') ?>
+				<?= __d('tags', 'Abort') ?>
 			</a>
 		</div>
 		<?= $this->Form->end() ?>

--- a/templates/Admin/Tags/add.php
+++ b/templates/Admin/Tags/add.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \Tags\Model\Entity\Tag $tag
+ * @var array $namespaces
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-plus me-2 text-muted"></i>
+	<?= __d('tags', 'Add Tag') ?>
+</h1>
+
+<div class="card card-tags">
+	<div class="card-body">
+		<?= $this->Form->create($tag) ?>
+		<div class="row">
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="label"><?= __d('tags', 'Label') ?> <span class="text-danger">*</span></label>
+				<?= $this->Form->control('label', [
+					'label' => false,
+					'class' => 'form-control' . ($tag->hasErrors('label') ? ' is-invalid' : ''),
+					'placeholder' => __d('tags', 'Enter tag label...'),
+				]) ?>
+				<?php if ($tag->hasErrors('label')): ?>
+				<div class="invalid-feedback"><?= implode(', ', $tag->getError('label')) ?></div>
+				<?php endif; ?>
+			</div>
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="slug"><?= __d('tags', 'Slug') ?></label>
+				<?= $this->Form->control('slug', [
+					'label' => false,
+					'class' => 'form-control' . ($tag->hasErrors('slug') ? ' is-invalid' : ''),
+					'placeholder' => __d('tags', 'Auto-generated from label if empty'),
+				]) ?>
+				<?php if ($tag->hasErrors('slug')): ?>
+				<div class="invalid-feedback"><?= implode(', ', $tag->getError('slug')) ?></div>
+				<?php endif; ?>
+				<small class="text-muted"><?= __d('tags', 'Leave empty to auto-generate from label.') ?></small>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="namespace"><?= __d('tags', 'Namespace') ?></label>
+				<?= $this->Form->control('namespace', [
+					'label' => false,
+					'class' => 'form-control' . ($tag->hasErrors('namespace') ? ' is-invalid' : ''),
+					'placeholder' => __d('tags', 'Optional namespace...'),
+					'list' => 'namespace-list',
+				]) ?>
+				<datalist id="namespace-list">
+					<?php foreach ($namespaces as $ns): ?>
+					<option value="<?= h($ns) ?>">
+					<?php endforeach; ?>
+				</datalist>
+				<?php if ($tag->hasErrors('namespace')): ?>
+				<div class="invalid-feedback"><?= implode(', ', $tag->getError('namespace')) ?></div>
+				<?php endif; ?>
+			</div>
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="color"><?= __d('tags', 'Color') ?></label>
+				<div class="input-group">
+					<?= $this->Form->control('color', [
+						'type' => 'color',
+						'label' => false,
+						'class' => 'form-control form-control-color',
+						'value' => $tag->color ?: '#6c757d',
+						'title' => __d('tags', 'Choose a color'),
+					]) ?>
+					<?= $this->Form->control('color', [
+						'label' => false,
+						'class' => 'form-control' . ($tag->hasErrors('color') ? ' is-invalid' : ''),
+						'placeholder' => '#FF5733',
+						'id' => 'color-text',
+					]) ?>
+				</div>
+				<?php if ($tag->hasErrors('color')): ?>
+				<div class="invalid-feedback d-block"><?= implode(', ', $tag->getError('color')) ?></div>
+				<?php endif; ?>
+				<small class="text-muted"><?= __d('tags', 'Optional hex color (e.g., #FF5733)') ?></small>
+			</div>
+		</div>
+		<div class="d-flex gap-2">
+			<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('tags', 'Save'), [
+				'class' => 'btn btn-primary',
+				'escapeTitle' => false,
+			]) ?>
+			<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
+				<?= __d('tags', 'Cancel') ?>
+			</a>
+		</div>
+		<?= $this->Form->end() ?>
+	</div>
+</div>
+
+<?php $this->append('script'); ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	var colorPicker = document.getElementById('color');
+	var colorText = document.getElementById('color-text');
+
+	if (colorPicker && colorText) {
+		colorPicker.addEventListener('input', function() {
+			colorText.value = this.value.toUpperCase();
+		});
+		colorText.addEventListener('input', function() {
+			if (/^#[0-9A-Fa-f]{6}$/.test(this.value)) {
+				colorPicker.value = this.value;
+			}
+		});
+	}
+});
+</script>
+<?php $this->end(); ?>

--- a/templates/Admin/Tags/change_namespace.php
+++ b/templates/Admin/Tags/change_namespace.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array $namespaces
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-exchange-alt me-2 text-muted"></i>
+	<?= __d('tags', 'Change Namespace') ?>
+</h1>
+
+<div class="card card-tags">
+	<div class="card-header">
+		<i class="fas fa-folder-open me-2"></i>
+		<?= __d('tags', 'Move Tags Between Namespaces') ?>
+	</div>
+	<div class="card-body">
+		<div class="alert alert-info">
+			<i class="fas fa-info-circle me-2"></i>
+			<?= __d('tags', 'This will move all tags from the source namespace to the target namespace. You can also move tags to or from "no namespace".') ?>
+		</div>
+
+		<?= $this->Form->create(null) ?>
+		<div class="row">
+			<div class="col-md-5 mb-3">
+				<label class="form-label" for="from-namespace">
+					<i class="fas fa-arrow-right me-1 text-danger"></i>
+					<?= __d('tags', 'Source Namespace') ?>
+				</label>
+				<select name="from_namespace" id="from-namespace" class="form-select" required>
+					<option value=""><?= __d('tags', '(no namespace)') ?></option>
+					<?php foreach ($namespaces as $ns): ?>
+					<?php if ($ns !== null): ?>
+					<option value="<?= h($ns) ?>"><?= h($ns) ?></option>
+					<?php endif; ?>
+					<?php endforeach; ?>
+				</select>
+			</div>
+
+			<div class="col-md-2 d-flex align-items-center justify-content-center mb-3">
+				<i class="fas fa-arrow-right fa-2x text-muted"></i>
+			</div>
+
+			<div class="col-md-5 mb-3">
+				<label class="form-label" for="to-namespace">
+					<i class="fas fa-bullseye me-1 text-success"></i>
+					<?= __d('tags', 'Target Namespace') ?>
+				</label>
+				<div class="input-group">
+					<select name="to_namespace" id="to-namespace-select" class="form-select">
+						<option value=""><?= __d('tags', '(no namespace)') ?></option>
+						<?php foreach ($namespaces as $ns): ?>
+						<?php if ($ns !== null): ?>
+						<option value="<?= h($ns) ?>"><?= h($ns) ?></option>
+						<?php endif; ?>
+						<?php endforeach; ?>
+					</select>
+				</div>
+				<div class="mt-2">
+					<label class="form-label small text-muted" for="to-namespace-new"><?= __d('tags', 'Or enter a new namespace:') ?></label>
+					<input type="text" name="to_namespace" id="to-namespace-new" class="form-control" placeholder="<?= __d('tags', 'New namespace name...') ?>">
+				</div>
+			</div>
+		</div>
+
+		<div class="d-flex gap-2">
+			<button type="submit" class="btn btn-primary">
+				<i class="fas fa-exchange-alt me-1"></i>
+				<?= __d('tags', 'Move Tags') ?>
+			</button>
+			<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
+				<?= __d('tags', 'Abort') ?>
+			</a>
+		</div>
+		<?= $this->Form->end() ?>
+	</div>
+</div>
+
+<?php if ($namespaces): ?>
+<div class="card card-tags mt-4">
+	<div class="card-header">
+		<i class="fas fa-list me-2"></i>
+		<?= __d('tags', 'Current Namespaces') ?>
+	</div>
+	<div class="card-body p-0">
+		<table class="table table-hover mb-0">
+			<thead class="table-light">
+				<tr>
+					<th><?= __d('tags', 'Namespace') ?></th>
+					<th class="text-end"><?= __d('tags', 'Actions') ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($namespaces as $ns): ?>
+				<tr>
+					<td>
+						<?php if ($ns === null): ?>
+						<em class="text-muted"><?= __d('tags', '(no namespace)') ?></em>
+						<?php else: ?>
+						<code><?= h($ns) ?></code>
+						<?php endif; ?>
+					</td>
+					<td class="text-end">
+						<a href="<?= $this->Url->build(['action' => 'index', '?' => ['namespace' => $ns ?? '']]) ?>" class="btn btn-sm btn-outline-secondary">
+							<i class="fas fa-eye me-1"></i>
+							<?= __d('tags', 'View Tags') ?>
+						</a>
+					</td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+</div>
+<?php endif; ?>
+
+<?php $this->append('script'); ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	var select = document.getElementById('to-namespace-select');
+	var input = document.getElementById('to-namespace-new');
+
+	// Clear input when select changes
+	select.addEventListener('change', function() {
+		if (this.value) {
+			input.value = '';
+		}
+	});
+
+	// Clear select when input is typed
+	input.addEventListener('input', function() {
+		if (this.value) {
+			select.value = '';
+		}
+	});
+});
+</script>
+<?php $this->end(); ?>

--- a/templates/Admin/Tags/duplicates.php
+++ b/templates/Admin/Tags/duplicates.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<array<\Tags\Model\Entity\Tag>> $duplicateGroups
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-clone me-2 text-muted"></i>
+	<?= __d('tags', 'Potential Duplicates') ?>
+</h1>
+
+<?php if ($duplicateGroups): ?>
+<div class="alert alert-info">
+	<i class="fas fa-info-circle me-2"></i>
+	<?= __d('tags', 'Found {0} groups of potentially duplicate tags. Review and merge as needed.', count($duplicateGroups)) ?>
+</div>
+
+<?php foreach ($duplicateGroups as $index => $group): ?>
+<div class="card card-tags mb-3">
+	<div class="card-header d-flex justify-content-between align-items-center">
+		<span>
+			<i class="fas fa-tags me-2"></i>
+			<?= __d('tags', 'Group {0}', $index + 1) ?>
+			<?php if ($group[0]->namespace): ?>
+			<span class="badge bg-secondary ms-2"><?= h($group[0]->namespace) ?></span>
+			<?php endif; ?>
+		</span>
+		<span class="badge bg-warning text-dark"><?= count($group) ?> <?= __d('tags', 'tags') ?></span>
+	</div>
+	<div class="card-body p-0">
+		<table class="table table-hover mb-0">
+			<thead class="table-light">
+				<tr>
+					<th><?= __d('tags', 'Label') ?></th>
+					<th><?= __d('tags', 'Slug') ?></th>
+					<th class="text-center"><?= __d('tags', 'Usage') ?></th>
+					<th class="text-end"><?= __d('tags', 'Actions') ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($group as $tag): ?>
+				<tr>
+					<td>
+						<?php if ($tag->color): ?>
+						<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+						<?php endif; ?>
+						<?= h($tag->label) ?>
+					</td>
+					<td><code><?= h($tag->slug) ?></code></td>
+					<td class="text-center">
+						<span class="badge bg-<?= $tag->counter > 0 ? 'primary' : 'secondary' ?>"><?= $tag->counter ?></span>
+					</td>
+					<td class="text-end">
+						<div class="btn-group btn-group-sm">
+							<a href="<?= $this->Url->build(['action' => 'view', $tag->id]) ?>" class="btn btn-outline-secondary" title="<?= __d('tags', 'View') ?>">
+								<i class="fas fa-eye"></i>
+							</a>
+							<a href="<?= $this->Url->build(['action' => 'edit', $tag->id]) ?>" class="btn btn-outline-primary" title="<?= __d('tags', 'Edit') ?>">
+								<i class="fas fa-edit"></i>
+							</a>
+						</div>
+					</td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+	<div class="card-footer">
+		<?php
+		// Find the tag with highest usage to suggest as target
+		$sortedGroup = $group;
+		usort($sortedGroup, fn($a, $b) => $b->counter <=> $a->counter);
+		$suggestedTarget = $sortedGroup[0];
+		?>
+		<a href="<?= $this->Url->build(['action' => 'merge', '?' => ['suggested_target' => $suggestedTarget->id]]) ?>" class="btn btn-sm btn-warning">
+			<i class="fas fa-compress-arrows-alt me-1"></i>
+			<?= __d('tags', 'Merge Tags in This Group') ?>
+		</a>
+		<small class="text-muted ms-2">
+			<?= __d('tags', 'Suggested target: {0} ({1} uses)', h($suggestedTarget->label), $suggestedTarget->counter) ?>
+		</small>
+	</div>
+</div>
+<?php endforeach; ?>
+
+<?php else: ?>
+<div class="alert alert-success">
+	<i class="fas fa-check-circle me-2"></i>
+	<?= __d('tags', 'No potential duplicates found. Your tags look good!') ?>
+</div>
+<?php endif; ?>
+
+<div class="mt-4">
+	<a href="<?= $this->Url->build(['controller' => 'TagsDashboard', 'action' => 'index']) ?>" class="btn btn-outline-secondary">
+		<i class="fas fa-arrow-left me-1"></i>
+		<?= __d('tags', 'Back to Dashboard') ?>
+	</a>
+</div>

--- a/templates/Admin/Tags/edit.php
+++ b/templates/Admin/Tags/edit.php
@@ -85,7 +85,7 @@
 				'escapeTitle' => false,
 			]) ?>
 			<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
-				<?= __d('tags', 'Cancel') ?>
+				<?= __d('tags', 'Abort') ?>
 			</a>
 		</div>
 		<?= $this->Form->end() ?>

--- a/templates/Admin/Tags/edit.php
+++ b/templates/Admin/Tags/edit.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \Tags\Model\Entity\Tag $tag
+ * @var array $namespaces
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-edit me-2 text-muted"></i>
+	<?= __d('tags', 'Edit Tag') ?>
+</h1>
+
+<div class="card card-tags">
+	<div class="card-body">
+		<?= $this->Form->create($tag) ?>
+		<div class="row">
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="label"><?= __d('tags', 'Label') ?> <span class="text-danger">*</span></label>
+				<?= $this->Form->control('label', [
+					'label' => false,
+					'class' => 'form-control' . ($tag->hasErrors('label') ? ' is-invalid' : ''),
+					'placeholder' => __d('tags', 'Enter tag label...'),
+				]) ?>
+				<?php if ($tag->hasErrors('label')): ?>
+				<div class="invalid-feedback"><?= implode(', ', $tag->getError('label')) ?></div>
+				<?php endif; ?>
+			</div>
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="slug"><?= __d('tags', 'Slug') ?> <span class="text-danger">*</span></label>
+				<?= $this->Form->control('slug', [
+					'label' => false,
+					'class' => 'form-control' . ($tag->hasErrors('slug') ? ' is-invalid' : ''),
+				]) ?>
+				<?php if ($tag->hasErrors('slug')): ?>
+				<div class="invalid-feedback"><?= implode(', ', $tag->getError('slug')) ?></div>
+				<?php endif; ?>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="namespace"><?= __d('tags', 'Namespace') ?></label>
+				<?= $this->Form->control('namespace', [
+					'label' => false,
+					'class' => 'form-control' . ($tag->hasErrors('namespace') ? ' is-invalid' : ''),
+					'placeholder' => __d('tags', 'Optional namespace...'),
+					'list' => 'namespace-list',
+				]) ?>
+				<datalist id="namespace-list">
+					<?php foreach ($namespaces as $ns): ?>
+					<option value="<?= h($ns) ?>">
+					<?php endforeach; ?>
+				</datalist>
+				<?php if ($tag->hasErrors('namespace')): ?>
+				<div class="invalid-feedback"><?= implode(', ', $tag->getError('namespace')) ?></div>
+				<?php endif; ?>
+			</div>
+			<div class="col-md-6 mb-3">
+				<label class="form-label" for="color"><?= __d('tags', 'Color') ?></label>
+				<div class="input-group">
+					<?= $this->Form->control('color', [
+						'type' => 'color',
+						'label' => false,
+						'class' => 'form-control form-control-color',
+						'value' => $tag->color ?: '#6c757d',
+						'title' => __d('tags', 'Choose a color'),
+						'id' => 'color-picker',
+					]) ?>
+					<?= $this->Form->control('color', [
+						'label' => false,
+						'class' => 'form-control' . ($tag->hasErrors('color') ? ' is-invalid' : ''),
+						'placeholder' => '#FF5733',
+						'id' => 'color-text',
+					]) ?>
+				</div>
+				<?php if ($tag->hasErrors('color')): ?>
+				<div class="invalid-feedback d-block"><?= implode(', ', $tag->getError('color')) ?></div>
+				<?php endif; ?>
+				<small class="text-muted"><?= __d('tags', 'Optional hex color (e.g., #FF5733)') ?></small>
+			</div>
+		</div>
+		<div class="d-flex gap-2">
+			<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('tags', 'Save'), [
+				'class' => 'btn btn-primary',
+				'escapeTitle' => false,
+			]) ?>
+			<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
+				<?= __d('tags', 'Cancel') ?>
+			</a>
+		</div>
+		<?= $this->Form->end() ?>
+	</div>
+</div>
+
+<?php $this->append('script'); ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	var colorPicker = document.getElementById('color-picker');
+	var colorText = document.getElementById('color-text');
+
+	if (colorPicker && colorText) {
+		// Sync color picker with text input on load
+		if (colorText.value && /^#[0-9A-Fa-f]{6}$/.test(colorText.value)) {
+			colorPicker.value = colorText.value;
+		}
+
+		colorPicker.addEventListener('input', function() {
+			colorText.value = this.value.toUpperCase();
+		});
+		colorText.addEventListener('input', function() {
+			if (/^#[0-9A-Fa-f]{6}$/.test(this.value)) {
+				colorPicker.value = this.value;
+			}
+		});
+	}
+});
+</script>
+<?php $this->end(); ?>

--- a/templates/Admin/Tags/index.php
+++ b/templates/Admin/Tags/index.php
@@ -28,7 +28,8 @@
 				<select name="namespace" class="form-select">
 					<option value=""><?= __d('tags', 'All namespaces') ?></option>
 					<?php foreach ($namespaces as $ns) : ?>
-					<option value="<?= h($ns ?? '') ?>" <?= ($namespace === $ns || ($namespace === '' && $ns === null)) ? 'selected' : '' ?>>
+					<?php $optionValue = $ns ?? '__none__'; ?>
+					<option value="<?= h($optionValue) ?>" <?= $namespace === $optionValue ? 'selected' : '' ?>>
 						<?= $ns ? h($ns) : __d('tags', '(no namespace)') ?>
 					</option>
 					<?php endforeach; ?>

--- a/templates/Admin/Tags/index.php
+++ b/templates/Admin/Tags/index.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \Cake\ORM\ResultSet<\Tags\Model\Entity\Tag> $tags
+ * @var array $namespaces
+ * @var string|null $namespace
+ * @var string|null $search
+ */
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+	<h1 class="mb-0">
+		<i class="fas fa-tags me-2 text-muted"></i>
+		<?= __d('tags', 'Tags') ?>
+	</h1>
+	<a href="<?= $this->Url->build(['action' => 'add']) ?>" class="btn btn-primary">
+		<i class="fas fa-plus me-1"></i>
+		<?= __d('tags', 'Add Tag') ?>
+	</a>
+</div>
+
+<!-- Filters -->
+<div class="card card-tags mb-4">
+	<div class="card-body">
+		<form method="get" class="row g-3">
+			<div class="col-md-4">
+				<label class="form-label"><?= __d('tags', 'Namespace') ?></label>
+				<select name="namespace" class="form-select">
+					<option value=""><?= __d('tags', 'All namespaces') ?></option>
+					<?php foreach ($namespaces as $ns) : ?>
+					<option value="<?= h($ns ?? '') ?>" <?= ($namespace === $ns || ($namespace === '' && $ns === null)) ? 'selected' : '' ?>>
+						<?= $ns ? h($ns) : __d('tags', '(no namespace)') ?>
+					</option>
+					<?php endforeach; ?>
+				</select>
+			</div>
+			<div class="col-md-4">
+				<label class="form-label"><?= __d('tags', 'Search') ?></label>
+				<input type="text" name="search" class="form-control" value="<?= h($search ?? '') ?>" placeholder="<?= __d('tags', 'Search by label or slug...') ?>">
+			</div>
+			<div class="col-md-4 d-flex align-items-end gap-2">
+				<button type="submit" class="btn btn-outline-primary">
+					<i class="fas fa-search me-1"></i>
+					<?= __d('tags', 'Filter') ?>
+				</button>
+				<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
+					<?= __d('tags', 'Clear') ?>
+				</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<!-- Tags Table -->
+<div class="card card-tags">
+	<div class="table-responsive">
+		<table class="table table-tags table-hover mb-0">
+			<thead>
+				<tr>
+					<th><?= $this->Paginator->sort('label', __d('tags', 'Label')) ?></th>
+					<th><?= $this->Paginator->sort('slug', __d('tags', 'Slug')) ?></th>
+					<th><?= $this->Paginator->sort('namespace', __d('tags', 'Namespace')) ?></th>
+					<th><?= __d('tags', 'Color') ?></th>
+					<th><?= $this->Paginator->sort('counter', __d('tags', 'Usage')) ?></th>
+					<th><?= $this->Paginator->sort('modified', __d('tags', 'Modified')) ?></th>
+					<th class="text-end"><?= __d('tags', 'Actions') ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ($tags->count() === 0) : ?>
+				<tr>
+					<td colspan="7" class="text-center text-muted py-4">
+						<i class="fas fa-tags fa-2x mb-2 opacity-50"></i>
+						<p class="mb-0"><?= __d('tags', 'No tags found.') ?></p>
+					</td>
+				</tr>
+				<?php else : ?>
+					<?php foreach ($tags as $tag) : ?>
+				<tr>
+					<td>
+						<strong><?= h($tag->label) ?></strong>
+					</td>
+					<td>
+						<code><?= h($tag->slug) ?></code>
+					</td>
+					<td>
+						<?php if ($tag->namespace) : ?>
+						<span class="badge bg-secondary"><?= h($tag->namespace) ?></span>
+						<?php else : ?>
+						<span class="text-muted">-</span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<?php if ($tag->color) : ?>
+						<span class="tag-color-swatch" style="background-color: <?= h($tag->color) ?>" title="<?= h($tag->color) ?>"></span>
+						<code class="ms-1"><?= h($tag->color) ?></code>
+						<?php else : ?>
+						<span class="text-muted">-</span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<span class="badge <?= $tag->counter > 0 ? 'bg-success' : 'bg-secondary' ?>"><?= $tag->counter ?></span>
+					</td>
+					<td>
+						<small class="text-muted"><?= $this->Time->timeAgoInWords($tag->modified) ?></small>
+					</td>
+					<td class="text-end">
+						<div class="btn-group btn-group-sm">
+							<a href="<?= $this->Url->build(['action' => 'view', $tag->id]) ?>" class="btn btn-outline-primary" title="<?= __d('tags', 'View') ?>">
+								<i class="fas fa-eye"></i>
+							</a>
+							<a href="<?= $this->Url->build(['action' => 'edit', $tag->id]) ?>" class="btn btn-outline-secondary" title="<?= __d('tags', 'Edit') ?>">
+								<i class="fas fa-edit"></i>
+							</a>
+							<?= $this->Form->postLink(
+								'<i class="fas fa-trash"></i>',
+								['action' => 'delete', $tag->id],
+								[
+									'class' => 'btn btn-outline-danger',
+									'escapeTitle' => false,
+									'confirm' => __d('tags', 'Delete tag "{0}"? This will also remove all associations.', $tag->label),
+									'title' => __d('tags', 'Delete'),
+									'block' => true,
+								],
+							) ?>
+						</div>
+					</td>
+				</tr>
+				    <?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	</div>
+	<?php if ($tags->count() > 0) : ?>
+	<div class="card-footer d-flex justify-content-between align-items-center">
+		<small class="text-muted">
+			<?= $this->Paginator->counter(__d('tags', 'Page {{page}} of {{pages}}, showing {{current}} of {{count}} tags')) ?>
+		</small>
+		<nav>
+			<ul class="pagination pagination-sm mb-0">
+				<?= $this->Paginator->first('«') ?>
+				<?= $this->Paginator->prev('‹') ?>
+				<?= $this->Paginator->numbers() ?>
+				<?= $this->Paginator->next('›') ?>
+				<?= $this->Paginator->last('»') ?>
+			</ul>
+		</nav>
+	</div>
+	<?php endif; ?>
+</div>

--- a/templates/Admin/Tags/index.php
+++ b/templates/Admin/Tags/index.php
@@ -27,10 +27,11 @@
 				<label class="form-label"><?= __d('tags', 'Namespace') ?></label>
 				<select name="namespace" class="form-select">
 					<option value=""><?= __d('tags', 'All namespaces') ?></option>
+					<option value="__none__" <?= $namespace === '__none__' ? 'selected' : '' ?>><?= __d('tags', '(no namespace)') ?></option>
 					<?php foreach ($namespaces as $ns) : ?>
-					<?php $optionValue = $ns ?? '__none__'; ?>
-					<option value="<?= h($optionValue) ?>" <?= $namespace === $optionValue ? 'selected' : '' ?>>
-						<?= $ns ? h($ns) : __d('tags', '(no namespace)') ?>
+					<?php if ($ns === null) { continue; } ?>
+					<option value="<?= h($ns) ?>" <?= $namespace === $ns ? 'selected' : '' ?>>
+						<?= h($ns) ?>
 					</option>
 					<?php endforeach; ?>
 				</select>

--- a/templates/Admin/Tags/merge.php
+++ b/templates/Admin/Tags/merge.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<\Tags\Model\Entity\Tag> $tags
+ * @var array $tagsByNamespace
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-compress-arrows-alt me-2 text-muted"></i>
+	<?= __d('tags', 'Merge Tags') ?>
+</h1>
+
+<div class="card card-tags">
+	<div class="card-header">
+		<i class="fas fa-info-circle me-2"></i>
+		<?= __d('tags', 'Select Tags to Merge') ?>
+	</div>
+	<div class="card-body">
+		<div class="alert alert-info">
+			<i class="fas fa-info-circle me-2"></i>
+			<?= __d('tags', 'Merging will move all associations from the source tag to the target tag, then delete the source tag. Tags must be in the same namespace.') ?>
+		</div>
+
+		<form method="get" action="<?= $this->Url->build(['action' => 'mergePreview']) ?>">
+			<div class="row">
+				<div class="col-md-5 mb-3">
+					<label class="form-label" for="source">
+						<i class="fas fa-arrow-right me-1 text-danger"></i>
+						<?= __d('tags', 'Source Tag (will be deleted)') ?>
+					</label>
+					<select name="source" id="source" class="form-select" required>
+						<option value=""><?= __d('tags', 'Select source tag...') ?></option>
+						<?php foreach ($tagsByNamespace as $namespace => $nsTags) : ?>
+						<optgroup label="<?= $namespace ? h($namespace) : __d('tags', '(no namespace)') ?>">
+							<?php foreach ($nsTags as $tag) : ?>
+							<option value="<?= $tag->id ?>" data-namespace="<?= h($tag->namespace ?? '') ?>">
+								<?= h($tag->label) ?> (<?= $tag->counter ?> uses)
+							</option>
+							<?php endforeach; ?>
+						</optgroup>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<div class="col-md-2 d-flex align-items-center justify-content-center mb-3">
+					<i class="fas fa-arrow-right fa-2x text-muted"></i>
+				</div>
+
+				<div class="col-md-5 mb-3">
+					<label class="form-label" for="target">
+						<i class="fas fa-bullseye me-1 text-success"></i>
+						<?= __d('tags', 'Target Tag (will receive associations)') ?>
+					</label>
+					<select name="target" id="target" class="form-select" required>
+						<option value=""><?= __d('tags', 'Select target tag...') ?></option>
+						<?php foreach ($tagsByNamespace as $namespace => $nsTags) : ?>
+						<optgroup label="<?= $namespace ? h($namespace) : __d('tags', '(no namespace)') ?>">
+							<?php foreach ($nsTags as $tag) : ?>
+							<option value="<?= $tag->id ?>" data-namespace="<?= h($tag->namespace ?? '') ?>">
+								<?= h($tag->label) ?> (<?= $tag->counter ?> uses)
+							</option>
+							<?php endforeach; ?>
+						</optgroup>
+						<?php endforeach; ?>
+					</select>
+				</div>
+			</div>
+
+			<div class="d-flex gap-2">
+				<button type="submit" class="btn btn-primary">
+					<i class="fas fa-search me-1"></i>
+					<?= __d('tags', 'Preview Merge') ?>
+				</button>
+				<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
+					<?= __d('tags', 'Cancel') ?>
+				</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<?php $this->append('script'); ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	var sourceSelect = document.getElementById('source');
+	var targetSelect = document.getElementById('target');
+
+	function filterTargetOptions() {
+		var sourceOption = sourceSelect.options[sourceSelect.selectedIndex];
+		var sourceNamespace = sourceOption ? sourceOption.dataset.namespace : '';
+		var sourceValue = sourceSelect.value;
+
+		// Show/hide target options based on namespace match
+		Array.from(targetSelect.options).forEach(function(option) {
+			if (option.value === '' || option.parentElement.tagName === 'SELECT') {
+				return; // Skip placeholder
+			}
+
+			var optionNamespace = option.dataset.namespace || '';
+
+			// Hide if same as source or different namespace
+			if (option.value === sourceValue) {
+				option.hidden = true;
+				option.disabled = true;
+			} else if (sourceValue && optionNamespace !== sourceNamespace) {
+				option.hidden = true;
+				option.disabled = true;
+			} else {
+				option.hidden = false;
+				option.disabled = false;
+			}
+		});
+
+		// Reset target if current selection is now hidden
+		var currentTarget = targetSelect.options[targetSelect.selectedIndex];
+		if (currentTarget && (currentTarget.hidden || currentTarget.disabled)) {
+			targetSelect.value = '';
+		}
+	}
+
+	sourceSelect.addEventListener('change', filterTargetOptions);
+});
+</script>
+<?php $this->end();

--- a/templates/Admin/Tags/merge.php
+++ b/templates/Admin/Tags/merge.php
@@ -73,7 +73,7 @@
 					<?= __d('tags', 'Preview Merge') ?>
 				</button>
 				<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
-					<?= __d('tags', 'Cancel') ?>
+					<?= __d('tags', 'Abort') ?>
 				</a>
 			</div>
 		</form>

--- a/templates/Admin/Tags/merge_preview.php
+++ b/templates/Admin/Tags/merge_preview.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \Tags\Model\Entity\Tag $sourceTag
+ * @var \Tags\Model\Entity\Tag $targetTag
+ * @var int $itemsToRetag
+ * @var int $duplicates
+ */
+
+$itemsToMove = $itemsToRetag - $duplicates;
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-compress-arrows-alt me-2 text-muted"></i>
+	<?= __d('tags', 'Merge Preview') ?>
+</h1>
+
+<div class="card card-tags mb-4">
+	<div class="card-header">
+		<i class="fas fa-eye me-2"></i>
+		<?= __d('tags', 'Merge Preview') ?>
+	</div>
+	<div class="card-body">
+		<div class="row text-center mb-4">
+			<div class="col-md-5">
+				<div class="card bg-danger bg-opacity-10 border-danger">
+					<div class="card-body">
+						<h5 class="text-danger">
+							<i class="fas fa-arrow-right me-1"></i>
+							<?= __d('tags', 'Source (will be deleted)') ?>
+						</h5>
+						<div class="fs-4 fw-bold"><?= h($sourceTag->label) ?></div>
+						<?php if ($sourceTag->namespace) : ?>
+						<span class="badge bg-secondary"><?= h($sourceTag->namespace) ?></span>
+						<?php endif; ?>
+						<?php if ($sourceTag->color) : ?>
+						<span class="tag-color-swatch ms-2" style="background-color: <?= h($sourceTag->color) ?>"></span>
+						<?php endif; ?>
+						<div class="mt-2 text-muted">
+							<code><?= h($sourceTag->slug) ?></code>
+							<span class="badge bg-secondary ms-2"><?= $sourceTag->counter ?> uses</span>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="col-md-2 d-flex align-items-center justify-content-center">
+				<i class="fas fa-arrow-right fa-2x text-muted"></i>
+			</div>
+
+			<div class="col-md-5">
+				<div class="card bg-success bg-opacity-10 border-success">
+					<div class="card-body">
+						<h5 class="text-success">
+							<i class="fas fa-bullseye me-1"></i>
+							<?= __d('tags', 'Target (will remain)') ?>
+						</h5>
+						<div class="fs-4 fw-bold"><?= h($targetTag->label) ?></div>
+						<?php if ($targetTag->namespace) : ?>
+						<span class="badge bg-secondary"><?= h($targetTag->namespace) ?></span>
+						<?php endif; ?>
+						<?php if ($targetTag->color) : ?>
+						<span class="tag-color-swatch ms-2" style="background-color: <?= h($targetTag->color) ?>"></span>
+						<?php endif; ?>
+						<div class="mt-2 text-muted">
+							<code><?= h($targetTag->slug) ?></code>
+							<span class="badge bg-secondary ms-2"><?= $targetTag->counter ?> uses</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- Impact Summary -->
+		<div class="alert alert-warning">
+			<h5 class="alert-heading">
+				<i class="fas fa-exclamation-triangle me-2"></i>
+				<?= __d('tags', 'Merge Impact') ?>
+			</h5>
+			<ul class="mb-0">
+				<li>
+					<strong><?= $itemsToMove ?></strong> <?= __d('tags', 'items will be re-tagged from "{0}" to "{1}"', h($sourceTag->label), h($targetTag->label)) ?>
+				</li>
+				<?php if ($duplicates > 0) : ?>
+				<li>
+					<strong><?= $duplicates ?></strong> <?= __d('tags', 'duplicate associations will be removed (items that already have both tags)') ?>
+				</li>
+				<?php endif; ?>
+				<li>
+					<?= __d('tags', 'The tag "{0}" will be permanently deleted', h($sourceTag->label)) ?>
+				</li>
+				<li>
+					<?= __d('tags', 'Target tag "{0}" will have approximately {1} uses after merge', h($targetTag->label), $targetTag->counter + $itemsToMove) ?>
+				</li>
+			</ul>
+		</div>
+
+		<!-- Confirm Form -->
+		<?= $this->Form->create(null, ['type' => 'post']) ?>
+		<?= $this->Form->hidden('source', ['value' => $sourceTag->id]) ?>
+		<?= $this->Form->hidden('target', ['value' => $targetTag->id]) ?>
+		<?= $this->Form->hidden('confirm', ['value' => '1']) ?>
+
+		<div class="d-flex gap-2">
+			<button type="submit" class="btn btn-danger">
+				<i class="fas fa-compress-arrows-alt me-1"></i>
+				<?= __d('tags', 'Confirm Merge') ?>
+			</button>
+			<a href="<?= $this->Url->build(['action' => 'merge']) ?>" class="btn btn-outline-secondary">
+				<i class="fas fa-arrow-left me-1"></i>
+				<?= __d('tags', 'Back') ?>
+			</a>
+		</div>
+		<?= $this->Form->end() ?>
+	</div>
+</div>

--- a/templates/Admin/Tags/orphaned.php
+++ b/templates/Admin/Tags/orphaned.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var iterable<\Tags\Model\Entity\Tag> $orphanedTags
+ * @var int $orphanedCount
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-unlink me-2 text-muted"></i>
+	<?= __d('tags', 'Orphaned Tags') ?>
+	<span class="badge bg-warning text-dark ms-2"><?= $orphanedCount ?></span>
+</h1>
+
+<?php if ($orphanedCount > 0): ?>
+<div class="alert alert-warning">
+	<i class="fas fa-exclamation-triangle me-2"></i>
+	<?= __d('tags', 'Found {0} orphaned tags (never used or counter = 0). Review and delete as needed.', $orphanedCount) ?>
+</div>
+
+<div class="card card-tags mb-4">
+	<div class="card-header d-flex justify-content-between align-items-center">
+		<span>
+			<i class="fas fa-list me-2"></i>
+			<?= __d('tags', 'Orphaned Tags List') ?>
+		</span>
+		<?= $this->Form->postLink(
+			'<i class="fas fa-trash-alt me-1"></i>' . __d('tags', 'Delete All Orphaned Tags'),
+			['action' => 'deleteOrphaned'],
+			[
+				'class' => 'btn btn-danger btn-sm',
+				'escapeTitle' => false,
+				'confirm' => __d('tags', 'Are you sure you want to delete all {0} orphaned tags? This cannot be undone.', $orphanedCount),
+				'block' => true,
+			]
+		) ?>
+	</div>
+	<div class="card-body p-0">
+		<table class="table table-hover mb-0">
+			<thead class="table-light">
+				<tr>
+					<th><?= __d('tags', 'Namespace') ?></th>
+					<th><?= __d('tags', 'Label') ?></th>
+					<th><?= __d('tags', 'Slug') ?></th>
+					<th><?= __d('tags', 'Created') ?></th>
+					<th class="text-end"><?= __d('tags', 'Actions') ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($orphanedTags as $tag): ?>
+				<tr>
+					<td>
+						<?php if ($tag->namespace): ?>
+						<code><?= h($tag->namespace) ?></code>
+						<?php else: ?>
+						<em class="text-muted"><?= __d('tags', '(none)') ?></em>
+						<?php endif; ?>
+					</td>
+					<td>
+						<?php if ($tag->color): ?>
+						<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+						<?php endif; ?>
+						<?= h($tag->label) ?>
+					</td>
+					<td><code><?= h($tag->slug) ?></code></td>
+					<td>
+						<small class="text-muted"><?= $this->Time->timeAgoInWords($tag->created) ?></small>
+					</td>
+					<td class="text-end">
+						<div class="btn-group btn-group-sm">
+							<a href="<?= $this->Url->build(['action' => 'edit', $tag->id]) ?>" class="btn btn-outline-primary" title="<?= __d('tags', 'Edit') ?>">
+								<i class="fas fa-edit"></i>
+							</a>
+							<?= $this->Form->postLink(
+								'<i class="fas fa-trash-alt"></i>',
+								['action' => 'delete', $tag->id],
+								[
+									'class' => 'btn btn-outline-danger',
+									'escapeTitle' => false,
+									'confirm' => __d('tags', 'Are you sure you want to delete "{0}"?', $tag->label),
+									'title' => __d('tags', 'Delete'),
+									'block' => true,
+								]
+							) ?>
+						</div>
+					</td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+	<?php if ($this->Paginator->total() > 1): ?>
+	<div class="card-footer">
+		<nav aria-label="Page navigation">
+			<ul class="pagination pagination-sm mb-0 justify-content-center">
+				<?= $this->Paginator->first('«', ['class' => 'page-link']) ?>
+				<?= $this->Paginator->prev('‹', ['class' => 'page-link']) ?>
+				<?= $this->Paginator->numbers(['class' => 'page-link']) ?>
+				<?= $this->Paginator->next('›', ['class' => 'page-link']) ?>
+				<?= $this->Paginator->last('»', ['class' => 'page-link']) ?>
+			</ul>
+		</nav>
+	</div>
+	<?php endif; ?>
+</div>
+
+<?php else: ?>
+<div class="alert alert-success">
+	<i class="fas fa-check-circle me-2"></i>
+	<?= __d('tags', 'No orphaned tags found. All tags are in use!') ?>
+</div>
+<?php endif; ?>
+
+<div class="mt-4">
+	<a href="<?= $this->Url->build(['controller' => 'TagsDashboard', 'action' => 'index']) ?>" class="btn btn-outline-secondary">
+		<i class="fas fa-arrow-left me-1"></i>
+		<?= __d('tags', 'Back to Dashboard') ?>
+	</a>
+</div>

--- a/templates/Admin/Tags/view.php
+++ b/templates/Admin/Tags/view.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \Tags\Model\Entity\Tag $tag
+ * @var array<\Tags\Model\Entity\Tagged> $usages
+ * @var array $usagesByModel
+ */
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+	<h1 class="mb-0">
+		<i class="fas fa-tag me-2 text-muted"></i>
+		<?= h($tag->label) ?>
+	</h1>
+	<div class="btn-group">
+		<a href="<?= $this->Url->build(['action' => 'edit', $tag->id]) ?>" class="btn btn-outline-primary">
+			<i class="fas fa-edit me-1"></i>
+			<?= __d('tags', 'Edit') ?>
+		</a>
+		<?= $this->Form->postLink(
+			'<i class="fas fa-trash me-1"></i>' . __d('tags', 'Delete'),
+			['action' => 'delete', $tag->id],
+			[
+				'class' => 'btn btn-outline-danger',
+				'escapeTitle' => false,
+				'confirm' => __d('tags', 'Delete tag "{0}"? This will also remove all associations.', $tag->label),
+				'block' => true,
+			],
+		) ?>
+	</div>
+</div>
+
+<div class="row">
+	<!-- Tag Details -->
+	<div class="col-lg-6 mb-4">
+		<div class="card card-tags h-100">
+			<div class="card-header">
+				<i class="fas fa-info-circle me-2"></i>
+				<?= __d('tags', 'Tag Details') ?>
+			</div>
+			<div class="card-body">
+				<table class="table table-borderless mb-0">
+					<tr>
+						<th style="width: 30%"><?= __d('tags', 'Label') ?></th>
+						<td><strong><?= h($tag->label) ?></strong></td>
+					</tr>
+					<tr>
+						<th><?= __d('tags', 'Slug') ?></th>
+						<td><code><?= h($tag->slug) ?></code></td>
+					</tr>
+					<tr>
+						<th><?= __d('tags', 'Namespace') ?></th>
+						<td>
+							<?php if ($tag->namespace) : ?>
+							<span class="badge bg-secondary"><?= h($tag->namespace) ?></span>
+							<?php else : ?>
+							<span class="text-muted">-</span>
+							<?php endif; ?>
+						</td>
+					</tr>
+					<tr>
+						<th><?= __d('tags', 'Color') ?></th>
+						<td>
+							<?php if ($tag->color) : ?>
+							<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+							<code><?= h($tag->color) ?></code>
+							<?php else : ?>
+							<span class="text-muted">-</span>
+							<?php endif; ?>
+						</td>
+					</tr>
+					<tr>
+						<th><?= __d('tags', 'Usage Count') ?></th>
+						<td><span class="badge <?= $tag->counter > 0 ? 'bg-success' : 'bg-secondary' ?>"><?= $tag->counter ?></span></td>
+					</tr>
+					<tr>
+						<th><?= __d('tags', 'Created') ?></th>
+						<td><?= $this->Time->nice($tag->created) ?></td>
+					</tr>
+					<tr>
+						<th><?= __d('tags', 'Modified') ?></th>
+						<td><?= $this->Time->nice($tag->modified) ?></td>
+					</tr>
+				</table>
+			</div>
+		</div>
+	</div>
+
+	<!-- Usage by Model -->
+	<div class="col-lg-6 mb-4">
+		<div class="card card-tags h-100">
+			<div class="card-header">
+				<i class="fas fa-database me-2"></i>
+				<?= __d('tags', 'Usage by Model') ?>
+			</div>
+			<?php if ($usagesByModel) : ?>
+			<div class="card-body p-0">
+				<ul class="list-group list-group-flush">
+					<?php foreach ($usagesByModel as $usage) : ?>
+					<li class="list-group-item d-flex justify-content-between align-items-center">
+						<code><?= h($usage['fk_model']) ?></code>
+						<span class="badge bg-primary rounded-pill"><?= $usage['count'] ?></span>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<?php else : ?>
+			<div class="card-body text-muted text-center">
+				<i class="fas fa-unlink fa-2x mb-2 opacity-50"></i>
+				<p class="mb-0"><?= __d('tags', 'This tag is not used anywhere.') ?></p>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+</div>
+
+<!-- Recent Usages -->
+<?php if ($usages) : ?>
+<div class="card card-tags">
+	<div class="card-header">
+		<i class="fas fa-history me-2"></i>
+		<?= __d('tags', 'Recent Usages') ?>
+	</div>
+	<div class="table-responsive">
+		<table class="table table-tags table-hover mb-0">
+			<thead>
+				<tr>
+					<th><?= __d('tags', 'Model') ?></th>
+					<th><?= __d('tags', 'Foreign Key') ?></th>
+					<th><?= __d('tags', 'Created') ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($usages as $usage) : ?>
+				<tr>
+					<td><code><?= h($usage->fk_model) ?></code></td>
+					<td><?= h($usage->fk_id) ?></td>
+					<td><small class="text-muted"><?= $this->Time->timeAgoInWords($usage->created) ?></small></td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+</div>
+<?php endif; ?>
+
+<div class="mt-4">
+	<a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-outline-secondary">
+		<i class="fas fa-arrow-left me-1"></i>
+		<?= __d('tags', 'Back to Tags') ?>
+	</a>
+</div>

--- a/templates/Admin/TagsDashboard/index.php
+++ b/templates/Admin/TagsDashboard/index.php
@@ -5,6 +5,7 @@
  * @var array $namespaces
  * @var array<\Tags\Model\Entity\Tag> $mostUsedTags
  * @var int $orphanedCount
+ * @var int $duplicateCount
  * @var array<\Tags\Model\Entity\Tag> $recentTags
  * @var int $totalTagged
  * @var array $models
@@ -18,7 +19,7 @@
 
 <!-- Stats Cards -->
 <div class="row g-3 mb-4">
-	<div class="col-6 col-md-3">
+	<div class="col-6 col-lg">
 		<?= $this->element('Tags.Tags/stats_card', [
 			'label' => __d('tags', 'Total Tags'),
 			'value' => $totalTags,
@@ -27,7 +28,7 @@
 			'link' => $this->Url->build(['controller' => 'Tags', 'action' => 'index']),
 		]) ?>
 	</div>
-	<div class="col-6 col-md-3">
+	<div class="col-6 col-lg">
 		<?= $this->element('Tags.Tags/stats_card', [
 			'label' => __d('tags', 'Tagged Items'),
 			'value' => $totalTagged,
@@ -35,7 +36,7 @@
 			'color' => 'success',
 		]) ?>
 	</div>
-	<div class="col-6 col-md-3">
+	<div class="col-6 col-lg">
 		<?= $this->element('Tags.Tags/stats_card', [
 			'label' => __d('tags', 'Namespaces'),
 			'value' => count($namespaces),
@@ -43,7 +44,7 @@
 			'color' => 'info',
 		]) ?>
 	</div>
-	<div class="col-6 col-md-3">
+	<div class="col-6 col-lg">
 		<?= $this->element('Tags.Tags/stats_card', [
 			'label' => __d('tags', 'Orphaned Tags'),
 			'value' => $orphanedCount,
@@ -51,6 +52,59 @@
 			'color' => $orphanedCount > 0 ? 'warning' : 'secondary',
 			'link' => $orphanedCount > 0 ? $this->Url->build(['controller' => 'Tags', 'action' => 'index', '?' => ['orphaned' => 1]]) : null,
 		]) ?>
+	</div>
+	<div class="col-6 col-lg">
+		<?= $this->element('Tags.Tags/stats_card', [
+			'label' => __d('tags', 'Duplicates'),
+			'value' => $duplicateCount,
+			'icon' => 'fa-clone',
+			'color' => $duplicateCount > 0 ? 'danger' : 'secondary',
+			'link' => $duplicateCount > 0 ? $this->Url->build(['controller' => 'Tags', 'action' => 'duplicates']) : null,
+		]) ?>
+	</div>
+</div>
+
+<!-- Maintenance Actions -->
+<div class="card card-tags mb-4">
+	<div class="card-header">
+		<i class="fas fa-wrench me-2"></i>
+		<?= __d('tags', 'Maintenance') ?>
+	</div>
+	<div class="card-body">
+		<div class="row g-3">
+			<div class="col-md-4">
+				<?= $this->Form->postLink(
+					'<i class="fas fa-trash-alt me-2"></i>' . __d('tags', 'Delete Orphaned Tags'),
+					['controller' => 'Tags', 'action' => 'deleteOrphaned'],
+					[
+						'class' => 'btn btn-outline-warning w-100',
+						'escapeTitle' => false,
+						'confirm' => __d('tags', 'Are you sure you want to delete all {0} orphaned tags?', $orphanedCount),
+						'block' => true,
+					]
+				) ?>
+				<small class="text-muted d-block mt-1"><?= __d('tags', 'Remove tags with zero usage') ?></small>
+			</div>
+			<div class="col-md-4">
+				<?= $this->Form->postLink(
+					'<i class="fas fa-sync-alt me-2"></i>' . __d('tags', 'Recalculate Counters'),
+					['controller' => 'Tags', 'action' => 'recalculateCounters'],
+					[
+						'class' => 'btn btn-outline-info w-100',
+						'escapeTitle' => false,
+						'block' => true,
+					]
+				) ?>
+				<small class="text-muted d-block mt-1"><?= __d('tags', 'Fix tag usage counts') ?></small>
+			</div>
+			<div class="col-md-4">
+				<a href="<?= $this->Url->build(['controller' => 'Tags', 'action' => 'export']) ?>" class="btn btn-outline-secondary w-100">
+					<i class="fas fa-download me-2"></i>
+					<?= __d('tags', 'Export to CSV') ?>
+				</a>
+				<small class="text-muted d-block mt-1"><?= __d('tags', 'Download all tags as CSV') ?></small>
+			</div>
+		</div>
 	</div>
 </div>
 

--- a/templates/Admin/TagsDashboard/index.php
+++ b/templates/Admin/TagsDashboard/index.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var int $totalTags
+ * @var array $namespaces
+ * @var array<\Tags\Model\Entity\Tag> $mostUsedTags
+ * @var int $orphanedCount
+ * @var array<\Tags\Model\Entity\Tag> $recentTags
+ * @var int $totalTagged
+ * @var array $models
+ */
+?>
+
+<h1 class="mb-4">
+	<i class="fas fa-tachometer-alt me-2 text-muted"></i>
+	<?= __d('tags', 'Dashboard') ?>
+</h1>
+
+<!-- Stats Cards -->
+<div class="row g-3 mb-4">
+	<div class="col-6 col-md-3">
+		<?= $this->element('Tags.Tags/stats_card', [
+			'label' => __d('tags', 'Total Tags'),
+			'value' => $totalTags,
+			'icon' => 'fa-tags',
+			'color' => 'primary',
+			'link' => $this->Url->build(['controller' => 'Tags', 'action' => 'index']),
+		]) ?>
+	</div>
+	<div class="col-6 col-md-3">
+		<?= $this->element('Tags.Tags/stats_card', [
+			'label' => __d('tags', 'Tagged Items'),
+			'value' => $totalTagged,
+			'icon' => 'fa-link',
+			'color' => 'success',
+		]) ?>
+	</div>
+	<div class="col-6 col-md-3">
+		<?= $this->element('Tags.Tags/stats_card', [
+			'label' => __d('tags', 'Namespaces'),
+			'value' => count($namespaces),
+			'icon' => 'fa-folder',
+			'color' => 'info',
+		]) ?>
+	</div>
+	<div class="col-6 col-md-3">
+		<?= $this->element('Tags.Tags/stats_card', [
+			'label' => __d('tags', 'Orphaned Tags'),
+			'value' => $orphanedCount,
+			'icon' => 'fa-unlink',
+			'color' => $orphanedCount > 0 ? 'warning' : 'secondary',
+			'link' => $orphanedCount > 0 ? $this->Url->build(['controller' => 'Tags', 'action' => 'index', '?' => ['orphaned' => 1]]) : null,
+		]) ?>
+	</div>
+</div>
+
+<div class="row">
+	<!-- Most Used Tags -->
+	<div class="col-lg-6 mb-4">
+		<div class="card card-tags h-100">
+			<div class="card-header">
+				<i class="fas fa-fire me-2 text-danger"></i>
+				<?= __d('tags', 'Most Used Tags') ?>
+			</div>
+			<?php if ($mostUsedTags): ?>
+			<div class="card-body p-0">
+				<ul class="list-group list-group-flush">
+					<?php foreach ($mostUsedTags as $tag): ?>
+					<li class="list-group-item d-flex justify-content-between align-items-center">
+						<span>
+							<?php if ($tag->color): ?>
+							<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+							<?php endif; ?>
+							<?php if ($tag->namespace): ?>
+							<small class="text-muted"><?= h($tag->namespace) ?>:</small>
+							<?php endif; ?>
+							<?= h($tag->label) ?>
+						</span>
+						<span class="badge bg-primary rounded-pill"><?= $tag->counter ?></span>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<?php else: ?>
+			<div class="card-body text-muted text-center">
+				<i class="fas fa-tags fa-2x mb-2 opacity-50"></i>
+				<p class="mb-0"><?= __d('tags', 'No tags used yet.') ?></p>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+
+	<!-- Tags by Namespace -->
+	<div class="col-lg-6 mb-4">
+		<div class="card card-tags h-100">
+			<div class="card-header">
+				<i class="fas fa-folder-open me-2 text-info"></i>
+				<?= __d('tags', 'Tags by Namespace') ?>
+			</div>
+			<?php if ($namespaces): ?>
+			<div class="card-body p-0">
+				<ul class="list-group list-group-flush">
+					<?php foreach ($namespaces as $ns): ?>
+					<li class="list-group-item d-flex justify-content-between align-items-center">
+						<span>
+							<?= $ns['namespace'] ? h($ns['namespace']) : '<em class="text-muted">' . __d('tags', '(no namespace)') . '</em>' ?>
+						</span>
+						<span class="badge bg-secondary rounded-pill"><?= $ns['count'] ?></span>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<?php else: ?>
+			<div class="card-body text-muted text-center">
+				<i class="fas fa-folder fa-2x mb-2 opacity-50"></i>
+				<p class="mb-0"><?= __d('tags', 'No tags created yet.') ?></p>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+</div>
+
+<div class="row">
+	<!-- Models Using Tags -->
+	<div class="col-lg-6 mb-4">
+		<div class="card card-tags h-100">
+			<div class="card-header">
+				<i class="fas fa-database me-2 text-success"></i>
+				<?= __d('tags', 'Models Using Tags') ?>
+			</div>
+			<?php if ($models): ?>
+			<div class="card-body p-0">
+				<ul class="list-group list-group-flush">
+					<?php foreach ($models as $model): ?>
+					<li class="list-group-item d-flex justify-content-between align-items-center">
+						<code><?= h($model['fk_model']) ?></code>
+						<span class="badge bg-success rounded-pill"><?= $model['count'] ?></span>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<?php else: ?>
+			<div class="card-body text-muted text-center">
+				<i class="fas fa-database fa-2x mb-2 opacity-50"></i>
+				<p class="mb-0"><?= __d('tags', 'No models tagged yet.') ?></p>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+
+	<!-- Recently Created Tags -->
+	<div class="col-lg-6 mb-4">
+		<div class="card card-tags h-100">
+			<div class="card-header">
+				<i class="fas fa-clock me-2 text-warning"></i>
+				<?= __d('tags', 'Recently Created Tags') ?>
+			</div>
+			<?php if ($recentTags): ?>
+			<div class="card-body p-0">
+				<ul class="list-group list-group-flush">
+					<?php foreach ($recentTags as $tag): ?>
+					<li class="list-group-item d-flex justify-content-between align-items-center">
+						<span>
+							<?php if ($tag->color): ?>
+							<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+							<?php endif; ?>
+							<?php if ($tag->namespace): ?>
+							<small class="text-muted"><?= h($tag->namespace) ?>:</small>
+							<?php endif; ?>
+							<?= h($tag->label) ?>
+						</span>
+						<small class="text-muted"><?= $this->Time->timeAgoInWords($tag->created) ?></small>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<?php else: ?>
+			<div class="card-body text-muted text-center">
+				<i class="fas fa-clock fa-2x mb-2 opacity-50"></i>
+				<p class="mb-0"><?= __d('tags', 'No tags created yet.') ?></p>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+</div>

--- a/templates/Admin/TagsDashboard/index.php
+++ b/templates/Admin/TagsDashboard/index.php
@@ -50,7 +50,7 @@
 			'value' => $orphanedCount,
 			'icon' => 'fa-unlink',
 			'color' => $orphanedCount > 0 ? 'warning' : 'secondary',
-			'link' => $orphanedCount > 0 ? $this->Url->build(['controller' => 'Tags', 'action' => 'index', '?' => ['orphaned' => 1]]) : null,
+			'link' => $orphanedCount > 0 ? $this->Url->build(['controller' => 'Tags', 'action' => 'orphaned']) : null,
 		]) ?>
 	</div>
 	<div class="col-6 col-lg">
@@ -73,17 +73,11 @@
 	<div class="card-body">
 		<div class="row g-3">
 			<div class="col-md-4">
-				<?= $this->Form->postLink(
-					'<i class="fas fa-trash-alt me-2"></i>' . __d('tags', 'Delete Orphaned Tags'),
-					['controller' => 'Tags', 'action' => 'deleteOrphaned'],
-					[
-						'class' => 'btn btn-outline-warning w-100',
-						'escapeTitle' => false,
-						'confirm' => __d('tags', 'Are you sure you want to delete all {0} orphaned tags?', $orphanedCount),
-						'block' => true,
-					]
-				) ?>
-				<small class="text-muted d-block mt-1"><?= __d('tags', 'Remove tags with zero usage') ?></small>
+				<a href="<?= $this->Url->build(['controller' => 'Tags', 'action' => 'orphaned']) ?>" class="btn btn-outline-warning w-100">
+					<i class="fas fa-unlink me-2"></i>
+					<?= __d('tags', 'Manage Orphaned Tags') ?>
+				</a>
+				<small class="text-muted d-block mt-1"><?= __d('tags', 'Review and remove unused tags') ?></small>
 			</div>
 			<div class="col-md-4">
 				<?= $this->Form->postLink(

--- a/templates/element/Tags/sidebar.php
+++ b/templates/element/Tags/sidebar.php
@@ -51,6 +51,10 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 				<i class="fas fa-clone"></i>
 				<?= __d('tags', 'Find Duplicates') ?>
 			</a>
+			<a class="nav-link <?= $isActive('Tags', ['orphaned']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'orphaned']) ?>">
+				<i class="fas fa-unlink"></i>
+				<?= __d('tags', 'Orphaned Tags') ?>
+			</a>
 			<a class="nav-link <?= $isActive('Tags', ['changeNamespace']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'changeNamespace']) ?>">
 				<i class="fas fa-exchange-alt"></i>
 				<?= __d('tags', 'Change Namespace') ?>

--- a/templates/element/Tags/sidebar.php
+++ b/templates/element/Tags/sidebar.php
@@ -47,6 +47,25 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 				<i class="fas fa-compress-arrows-alt"></i>
 				<?= __d('tags', 'Merge Tags') ?>
 			</a>
+			<a class="nav-link <?= $isActive('Tags', ['duplicates']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'duplicates']) ?>">
+				<i class="fas fa-clone"></i>
+				<?= __d('tags', 'Find Duplicates') ?>
+			</a>
+			<a class="nav-link <?= $isActive('Tags', ['changeNamespace']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'changeNamespace']) ?>">
+				<i class="fas fa-exchange-alt"></i>
+				<?= __d('tags', 'Change Namespace') ?>
+			</a>
+		</nav>
+	</div>
+
+	<!-- Tools -->
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __d('tags', 'Tools') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'export']) ?>">
+				<i class="fas fa-download"></i>
+				<?= __d('tags', 'Export CSV') ?>
+			</a>
 		</nav>
 	</div>
 </aside>

--- a/templates/element/Tags/sidebar.php
+++ b/templates/element/Tags/sidebar.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tags Admin Sidebar Navigation
+ *
+ * @var \Cake\View\View $this
+ */
+
+$controller = $this->getRequest()->getParam('controller');
+$action = $this->getRequest()->getParam('action');
+
+$isActive = function (string $c, ?array $actions = null) use ($controller, $action): string {
+	if ($controller !== $c) {
+		return '';
+	}
+	if ($actions === null) {
+		return 'active';
+	}
+
+	return in_array($action, $actions, true) ? 'active' : '';
+};
+?>
+<aside class="tags-sidebar d-none d-lg-block">
+	<!-- Navigation -->
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __d('tags', 'Navigation') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link <?= $isActive('TagsDashboard', ['index']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'TagsDashboard', 'action' => 'index']) ?>">
+				<i class="fas fa-tachometer-alt"></i>
+				<?= __d('tags', 'Dashboard') ?>
+			</a>
+			<a class="nav-link <?= $isActive('Tags', ['index', 'view', 'add', 'edit']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'index']) ?>">
+				<i class="fas fa-tags"></i>
+				<?= __d('tags', 'Tags') ?>
+			</a>
+		</nav>
+	</div>
+
+	<!-- Actions -->
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __d('tags', 'Actions') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link <?= $isActive('Tags', ['add']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'add']) ?>">
+				<i class="fas fa-plus"></i>
+				<?= __d('tags', 'Add Tag') ?>
+			</a>
+			<a class="nav-link <?= $isActive('Tags', ['merge', 'mergePreview']) ?>" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'Tags', 'action' => 'merge']) ?>">
+				<i class="fas fa-compress-arrows-alt"></i>
+				<?= __d('tags', 'Merge Tags') ?>
+			</a>
+		</nav>
+	</div>
+</aside>

--- a/templates/element/Tags/stats_card.php
+++ b/templates/element/Tags/stats_card.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Stats Card Element
+ *
+ * @var \Cake\View\View $this
+ * @var string $label The card label
+ * @var string|int $value The stat value
+ * @var string $icon Font Awesome icon class (e.g., 'fa-tags')
+ * @var string $color Bootstrap color (primary, success, warning, danger, info, secondary)
+ * @var string|null $link Optional link URL
+ */
+
+$color = $color ?? 'primary';
+$icon = $icon ?? 'fa-chart-bar';
+$link = $link ?? null;
+
+$bgOpacity = [
+	'danger' => 'bg-danger bg-opacity-10',
+	'warning' => 'bg-warning bg-opacity-10',
+	'success' => 'bg-success bg-opacity-10',
+	'info' => 'bg-info bg-opacity-10',
+	'primary' => 'bg-primary bg-opacity-10',
+	'secondary' => 'bg-secondary bg-opacity-10',
+];
+
+$textColor = [
+	'danger' => 'text-danger',
+	'warning' => 'text-warning',
+	'success' => 'text-success',
+	'info' => 'text-info',
+	'primary' => 'text-primary',
+	'secondary' => 'text-secondary',
+];
+?>
+<?php if ($link) : ?>
+<a href="<?= h($link) ?>" class="text-decoration-none">
+<?php endif; ?>
+<div class="card stats-card h-100">
+	<div class="card-body">
+		<div class="d-flex align-items-center">
+			<div class="stats-icon <?= $bgOpacity[$color] ?? $bgOpacity['primary'] ?> <?= $textColor[$color] ?? $textColor['primary'] ?> me-3">
+				<i class="fas <?= h($icon) ?>"></i>
+			</div>
+			<div>
+				<div class="stats-value"><?= h($value) ?></div>
+				<div class="stats-label"><?= h($label) ?></div>
+			</div>
+		</div>
+	</div>
+</div>
+<?php if ($link) : ?>
+</a>
+<?php endif;

--- a/templates/element/flash/error.php
+++ b/templates/element/flash/error.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var array $params
+ * @var string $message
+ */
+
+$class = 'alert alert-danger alert-dismissible fade show tags-flash';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-exclamation-circle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/flash/info.php
+++ b/templates/element/flash/info.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var array $params
+ * @var string $message
+ */
+
+$class = 'alert alert-info alert-dismissible fade show tags-flash';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-info-circle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/flash/success.php
+++ b/templates/element/flash/success.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var array $params
+ * @var string $message
+ */
+
+$class = 'alert alert-success alert-dismissible fade show tags-flash';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-check-circle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/flash/warning.php
+++ b/templates/element/flash/warning.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var array $params
+ * @var string $message
+ */
+
+$class = 'alert alert-warning alert-dismissible fade show tags-flash';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-exclamation-triangle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/layout/tags.php
+++ b/templates/layout/tags.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Tags Admin Layout
+ *
+ * Self-contained admin layout using Bootstrap 5 and Font Awesome 6 via CDN.
+ * Completely isolated from host application's CSS/JS.
+ *
+ * @var \Cake\View\View $this
+ */
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?= $this->fetch('title') ? strip_tags($this->fetch('title')) . ' - ' : '' ?>Tags Admin</title>
+
+	<!-- Bootstrap 5.3.3 CSS -->
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+
+	<!-- Font Awesome 6.7.2 -->
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" rel="stylesheet" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous">
+
+	<style>
+		:root {
+			--tags-primary: #0d6efd;
+			--tags-success: #198754;
+			--tags-warning: #ffc107;
+			--tags-danger: #dc3545;
+			--tags-info: #0dcaf0;
+			--tags-secondary: #6c757d;
+			--tags-dark: #212529;
+			--tags-light: #f8f9fa;
+			--tags-sidebar-bg: linear-gradient(135deg, #4a5568 0%, #2d3748 100%);
+			--tags-sidebar-width: 260px;
+		}
+
+		body {
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+			background-color: #f4f6f9;
+			min-height: 100vh;
+		}
+
+		/* Navbar */
+		.tags-navbar {
+			background: var(--tags-dark);
+			box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+		}
+
+		.tags-navbar .navbar-brand {
+			font-weight: 600;
+			color: #fff;
+		}
+
+		.tags-navbar .navbar-brand i {
+			color: var(--tags-info);
+		}
+
+		/* Sidebar */
+		.tags-sidebar {
+			background: var(--tags-sidebar-bg);
+			min-height: calc(100vh - 56px);
+			width: var(--tags-sidebar-width);
+			position: fixed;
+			left: 0;
+			top: 56px;
+			padding: 1.5rem 0;
+			overflow-y: auto;
+		}
+
+		.tags-sidebar .nav-section {
+			padding: 0 1rem;
+			margin-bottom: 1.5rem;
+		}
+
+		.tags-sidebar .nav-section-title {
+			color: rgba(255,255,255,0.5);
+			font-size: 0.75rem;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			padding: 0 0.75rem;
+			margin-bottom: 0.5rem;
+		}
+
+		.tags-sidebar .nav-link {
+			color: rgba(255,255,255,0.8);
+			padding: 0.6rem 0.75rem;
+			border-radius: 0.375rem;
+			margin-bottom: 0.25rem;
+			transition: all 0.2s ease;
+		}
+
+		.tags-sidebar .nav-link:hover {
+			color: #fff;
+			background: rgba(255,255,255,0.1);
+		}
+
+		.tags-sidebar .nav-link.active {
+			color: #fff;
+			background: var(--tags-primary);
+		}
+
+		.tags-sidebar .nav-link i {
+			width: 1.25rem;
+			margin-right: 0.5rem;
+		}
+
+		/* Main Content */
+		.tags-main {
+			margin-left: var(--tags-sidebar-width);
+			padding: 1.5rem;
+			min-height: calc(100vh - 56px);
+		}
+
+		/* Stats Cards */
+		.stats-card {
+			border: none;
+			border-radius: 0.5rem;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+			transition: transform 0.2s ease, box-shadow 0.2s ease;
+			overflow: hidden;
+		}
+
+		.stats-card:hover {
+			transform: translateY(-2px);
+			box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+		}
+
+		.stats-card .card-body {
+			padding: 1.25rem;
+		}
+
+		.stats-card .stats-icon {
+			width: 48px;
+			height: 48px;
+			border-radius: 0.5rem;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-size: 1.25rem;
+		}
+
+		.stats-card .stats-value {
+			font-size: 1.75rem;
+			font-weight: 700;
+			line-height: 1.2;
+		}
+
+		.stats-card .stats-label {
+			color: var(--tags-secondary);
+			font-size: 0.875rem;
+		}
+
+		/* Tables */
+		.table-tags {
+			background: #fff;
+			border-radius: 0.5rem;
+			overflow: hidden;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+		}
+
+		.table-tags thead th {
+			background: var(--tags-light);
+			border-bottom: 2px solid #dee2e6;
+			font-weight: 600;
+			text-transform: uppercase;
+			font-size: 0.75rem;
+			letter-spacing: 0.05em;
+			color: var(--tags-secondary);
+		}
+
+		.table-tags tbody tr:hover {
+			background-color: rgba(13, 110, 253, 0.05);
+		}
+
+		/* Cards */
+		.card-tags {
+			border: none;
+			border-radius: 0.5rem;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+		}
+
+		.card-tags .card-header {
+			background: var(--tags-light);
+			border-bottom: 1px solid #dee2e6;
+			font-weight: 600;
+		}
+
+		/* Tag badges */
+		.tag-badge {
+			display: inline-flex;
+			align-items: center;
+			padding: 0.35em 0.65em;
+			font-size: 0.875rem;
+			font-weight: 500;
+			border-radius: 0.375rem;
+		}
+
+		.tag-color-swatch {
+			width: 16px;
+			height: 16px;
+			border-radius: 3px;
+			border: 1px solid rgba(0,0,0,0.1);
+			display: inline-block;
+		}
+
+		/* Alerts/Flash */
+		.tags-flash {
+			border: none;
+			border-radius: 0.5rem;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+		}
+
+		/* Mobile Navigation */
+		.tags-mobile-toggle {
+			color: #fff;
+			background: transparent;
+			border: 1px solid rgba(255,255,255,0.2);
+			padding: 0.5rem 1rem;
+			border-radius: 0.375rem;
+		}
+
+		/* Responsive */
+		@media (max-width: 991.98px) {
+			.tags-sidebar {
+				display: none;
+				position: fixed;
+				z-index: 1040;
+				width: 100%;
+				top: 56px;
+				left: 0;
+				padding-bottom: 2rem;
+			}
+
+			.tags-sidebar.show {
+				display: block;
+			}
+
+			.tags-main {
+				margin-left: 0;
+			}
+		}
+
+		/* Form styles */
+		.form-label {
+			font-weight: 500;
+		}
+
+		/* Namespace filter pills */
+		.namespace-filters .btn {
+			margin-right: 0.25rem;
+			margin-bottom: 0.25rem;
+		}
+	</style>
+
+	<?= $this->fetch('css') ?>
+</head>
+<body>
+	<!-- Top Navbar -->
+	<nav class="navbar navbar-expand-lg tags-navbar">
+		<div class="container-fluid">
+			<a class="navbar-brand" href="<?= $this->Url->build(['plugin' => 'Tags', 'prefix' => 'Admin', 'controller' => 'TagsDashboard', 'action' => 'index']) ?>">
+				<i class="fas fa-tags me-2"></i>
+				Tags
+			</a>
+
+			<!-- Mobile toggle -->
+			<button class="navbar-toggler tags-mobile-toggle d-lg-none" type="button" onclick="document.querySelector('.tags-sidebar').classList.toggle('show')">
+				<i class="fas fa-bars"></i>
+			</button>
+		</div>
+	</nav>
+
+	<!-- Sidebar -->
+	<?= $this->element('Tags.Tags/sidebar') ?>
+
+	<!-- Main Content -->
+	<main class="tags-main">
+		<!-- Flash Messages -->
+		<?php
+		$flashTypes = ['success', 'error', 'warning', 'info'];
+		foreach ($flashTypes as $type) {
+			echo $this->Flash->render($type);
+		}
+		echo $this->Flash->render();
+		?>
+
+		<?= $this->fetch('content') ?>
+	</main>
+
+	<!-- Bootstrap JS -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+	<?= $this->fetch('script') ?>
+	<?= $this->fetch('postLink') ?>
+</body>
+</html>

--- a/tests/test_app/src/Controller/AppController.php
+++ b/tests/test_app/src/Controller/AppController.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Cake\Controller\Controller;
+
+/**
+ * Application Controller
+ *
+ * Stub for testing the Tags plugin admin backend.
+ */
+class AppController extends Controller {
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void {
+		parent::initialize();
+
+		$this->loadComponent('Flash');
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR introduces a modern, self-contained admin dashboard for the Tags plugin, similar to [DatabaseLog#56](https://github.com/dereuromark/CakePHP-DatabaseLog/pull/56).

### Key Features

- **Bootstrap 5.3.3 + Font Awesome 6.7.2** via CDN with SRI hashes
- **Isolated base controller** (`TagsAppController`) that extends `App\Controller\AppController` by default
- **Configuration-driven layout** - can be enabled/disabled via config
- **Backwards compatible** - existing behavior preserved; standalone mode is opt-in

### Dashboard Features

- Stats cards showing: total tags, tagged items, namespaces, orphaned tags
- Most used tags list (top 10)
- Tags by namespace breakdown
- Models using tags
- Recently created tags
- Sidebar with quick navigation

### Tags CRUD

- Index with search and namespace filtering
- View with usage details and recent associations
- Add/Edit with color picker and namespace suggestions
- Delete with confirmation

### Tag Merge Feature

- Two-step merge process with preview
- Shows impact before executing (items to re-tag, duplicates to remove)
- Namespace-scoped (can only merge tags within same namespace)
- Source tag is deleted after merge, target tag receives all associations

### Configuration Options

```php
'Tags' => [
    'standalone' => false,        // Set to true for isolated admin
    'adminLayout' => null,        // null = plugin layout, false = app layout, string = custom
],
```

### Routes

- `/tags/admin/` - Dashboard
- `/tags/admin/tags` - Tags index
- `/tags/admin/tags/add` - Add tag
- `/tags/admin/tags/edit/{id}` - Edit tag
- `/tags/admin/tags/view/{id}` - View tag
- `/tags/admin/tags/merge` - Merge tags (step 1)
- `/tags/admin/tags/merge-preview` - Merge preview (step 2)