### PR TITLE
Fix namespace move handling

### DIFF
--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -427,15 +427,11 @@ class TagsController extends TagsAppController {
 			->toArray();
 
 		if ($this->request->is('post')) {
-			$fromNamespace = $this->request->getData('from_namespace');
-			$toNamespace = $this->request->getData('to_namespace');
-
-			// Handle empty string as null
-			if ($fromNamespace === '') {
-				$fromNamespace = null;
-			}
-			if ($toNamespace === '') {
-				$toNamespace = null;
+			$fromNamespace = $this->normalizeNamespaceInput($this->request->getData('from_namespace'));
+			$toNamespace = $this->normalizeNamespaceInput($this->request->getData('to_namespace_select'));
+			$newNamespace = trim((string)$this->request->getData('to_namespace_new'));
+			if ($newNamespace !== '') {
+				$toNamespace = $newNamespace;
 			}
 
 			if ($fromNamespace === $toNamespace) {
@@ -446,10 +442,15 @@ class TagsController extends TagsAppController {
 				return null;
 			}
 
-			$count = $this->Tags->updateAll(
-				['namespace' => $toNamespace],
-				['namespace IS' => $fromNamespace],
-			);
+			try {
+				$count = $this->Tags->moveNamespace($fromNamespace, $toNamespace);
+			} catch (RuntimeException $exception) {
+				$this->Flash->error(__d('tags', 'The namespace move was aborted because conflicting tag slugs already exist in the target namespace.'));
+
+				$this->set(compact('namespaces'));
+
+				return null;
+			}
 
 			if ($count > 0) {
 				$this->Flash->success(__d('tags', '{0} tags have been moved to the new namespace.', $count));
@@ -463,6 +464,20 @@ class TagsController extends TagsAppController {
 		$this->set(compact('namespaces'));
 
 		return null;
+	}
+
+	/**
+	 * Normalize form namespace values, including the null sentinel.
+	 *
+	 * @param mixed $value Raw request value.
+	 * @return string|null
+	 */
+	protected function normalizeNamespaceInput(mixed $value): ?string {
+		if ($value === '__none__' || $value === '' || $value === null) {
+			return null;
+		}
+
+		return (string)$value;
 	}
 
 }

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -206,6 +206,58 @@ class TagsTable extends Table {
 	}
 
 	/**
+	 * Count slug conflicts for a namespace move.
+	 *
+	 * A conflict exists when the target namespace already contains a tag with the
+	 * same slug as one of the source namespace tags.
+	 *
+	 * @param string|null $fromNamespace Source namespace.
+	 * @param string|null $toNamespace Target namespace.
+	 * @return int Number of conflicting target tags.
+	 */
+	public function countNamespaceConflicts(?string $fromNamespace, ?string $toNamespace): int {
+		$sourceSlugs = $this->find()
+			->select(['slug'])
+			->where($this->namespaceConditions($fromNamespace))
+			->disableHydration()
+			->all()
+			->extract('slug')
+			->toList();
+
+		if (!$sourceSlugs) {
+			return 0;
+		}
+
+		return $this->find()
+			->where($this->namespaceConditions($toNamespace))
+			->where(['slug IN' => $sourceSlugs])
+			->count();
+	}
+
+	/**
+	 * Move all tags from one namespace to another.
+	 *
+	 * @param string|null $fromNamespace Source namespace.
+	 * @param string|null $toNamespace Target namespace.
+	 * @throws \RuntimeException When duplicate slugs already exist in the target namespace.
+	 * @return int Number of updated rows.
+	 */
+	public function moveNamespace(?string $fromNamespace, ?string $toNamespace): int {
+		$conflicts = $this->countNamespaceConflicts($fromNamespace, $toNamespace);
+		if ($conflicts) {
+			throw new RuntimeException(sprintf(
+				'Cannot move namespace: %d conflicting slug(s) already exist in the target namespace.',
+				$conflicts,
+			));
+		}
+
+		return $this->updateAll(
+			['namespace' => $toNamespace],
+			$this->namespaceConditions($fromNamespace),
+		);
+	}
+
+	/**
 	 * Delete all orphaned tags (counter = 0).
 	 *
 	 * @param string|null $namespace Optional namespace to filter by.
@@ -320,6 +372,20 @@ class TagsTable extends Table {
 			// Delete source tag
 			return $this->delete($sourceTag);
 		});
+	}
+
+	/**
+	 * Build namespace conditions, including null namespace support.
+	 *
+	 * @param string|null $namespace Namespace value.
+	 * @return array<string, string|null>
+	 */
+	protected function namespaceConditions(?string $namespace): array {
+		if ($namespace === null) {
+			return ['namespace IS' => null];
+		}
+
+		return ['namespace' => $namespace];
 	}
 
 }

--- a/templates/Admin/Tags/change_namespace.php
+++ b/templates/Admin/Tags/change_namespace.php
@@ -28,8 +28,8 @@
 					<i class="fas fa-arrow-right me-1 text-danger"></i>
 					<?= __d('tags', 'Source Namespace') ?>
 				</label>
-				<select name="from_namespace" id="from-namespace" class="form-select" required>
-					<option value=""><?= __d('tags', '(no namespace)') ?></option>
+				<select name="from_namespace" id="from-namespace" class="form-select">
+					<option value="__none__"><?= __d('tags', '(no namespace)') ?></option>
 					<?php foreach ($namespaces as $ns): ?>
 					<?php if ($ns !== null): ?>
 					<option value="<?= h($ns) ?>"><?= h($ns) ?></option>
@@ -47,9 +47,9 @@
 					<i class="fas fa-bullseye me-1 text-success"></i>
 					<?= __d('tags', 'Target Namespace') ?>
 				</label>
-				<div class="input-group">
-					<select name="to_namespace" id="to-namespace-select" class="form-select">
-						<option value=""><?= __d('tags', '(no namespace)') ?></option>
+					<div class="input-group">
+						<select name="to_namespace_select" id="to-namespace-select" class="form-select">
+							<option value="__none__"><?= __d('tags', '(no namespace)') ?></option>
 						<?php foreach ($namespaces as $ns): ?>
 						<?php if ($ns !== null): ?>
 						<option value="<?= h($ns) ?>"><?= h($ns) ?></option>
@@ -59,7 +59,7 @@
 				</div>
 				<div class="mt-2">
 					<label class="form-label small text-muted" for="to-namespace-new"><?= __d('tags', 'Or enter a new namespace:') ?></label>
-					<input type="text" name="to_namespace" id="to-namespace-new" class="form-control" placeholder="<?= __d('tags', 'New namespace name...') ?>">
+						<input type="text" name="to_namespace_new" id="to-namespace-new" class="form-control" placeholder="<?= __d('tags', 'New namespace name...') ?>">
 				</div>
 			</div>
 		</div>
@@ -102,7 +102,7 @@
 						<?php endif; ?>
 					</td>
 					<td class="text-end">
-						<a href="<?= $this->Url->build(['action' => 'index', '?' => ['namespace' => $ns ?? '']]) ?>" class="btn btn-sm btn-outline-secondary">
+						<a href="<?= $this->Url->build(['action' => 'index', '?' => ['namespace' => $ns ?? '__none__']]) ?>" class="btn btn-sm btn-outline-secondary">
 							<i class="fas fa-eye me-1"></i>
 							<?= __d('tags', 'View Tags') ?>
 						</a>

--- a/tests/TestCase/Controller/Admin/TagsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TagsControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Test\TestCase\Controller\Admin;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class TagsControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Tags.Tags',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->disableErrorHandlerMiddleware();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testChangeNamespacePageUsesDistinctFormFields(): void {
+		$this->get('/admin/tags/tags/change-namespace');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('name="to_namespace_select"');
+		$this->assertResponseContains('name="to_namespace_new"');
+		$this->assertResponseContains('?namespace=__none__');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testChangeNamespaceMovesTagsToExistingNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'accent',
+			'label' => 'Accent',
+		]));
+
+		$this->post('/admin/tags/tags/change-namespace', [
+			'from_namespace' => '__none__',
+			'to_namespace_select' => 'palette',
+			'to_namespace_new' => '',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags/change-namespace');
+
+		$result = $tagsTable->find()
+			->where(['namespace' => 'palette'])
+			->orderByAsc('slug')
+			->all()
+			->extract('slug')
+			->toList();
+		$this->assertSame(['accent', 'color', 'dark-color'], $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testChangeNamespaceRejectsConflicts(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'color',
+			'label' => 'Color In Palette',
+		]));
+
+		$this->post('/admin/tags/tags/change-namespace', [
+			'from_namespace' => '__none__',
+			'to_namespace_select' => 'palette',
+			'to_namespace_new' => '',
+		]);
+
+		$this->assertResponseOk();
+		$this->assertNoRedirect();
+
+		$result = $tagsTable->find()
+			->where(['namespace IS' => null])
+			->orderByAsc('slug')
+			->all()
+			->extract('slug')
+			->toList();
+		$this->assertSame(['color', 'dark-color'], $result);
+	}
+
+}

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -130,6 +130,40 @@ class TagsTableTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testMoveNamespace(): void {
+		$count = $this->Tags->moveNamespace(null, 'palette');
+
+		$this->assertSame(2, $count);
+
+		$result = $this->Tags->find()
+			->where(['namespace' => 'palette'])
+			->orderByAsc('slug')
+			->all()
+			->extract('slug')
+			->toList();
+		$this->assertSame(['color', 'dark-color'], $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMoveNamespaceWithConflicts(): void {
+		$entity = $this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'color',
+			'label' => 'Color In Palette',
+		]);
+		$this->Tags->saveOrFail($entity);
+
+		$this->assertSame(1, $this->Tags->countNamespaceConflicts(null, 'palette'));
+
+		$this->expectExceptionMessage('conflicting slug(s)');
+		$this->Tags->moveNamespace(null, 'palette');
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testMultipleTagsPerModel() {
 		//TableRegistry::clear();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,10 @@ Configure::write('App', [
 	'encoding' => 'utf-8',
 ]);
 
+if (!class_exists('App\\Controller\\AppController') && class_exists('TestApp\\Controller\\AppController')) {
+	class_alias('TestApp\\Controller\\AppController', 'App\\Controller\\AppController');
+}
+
 Plugin::getCollection()->add(new TagsPlugin());
 Plugin::getCollection()->add(new ToolsPlugin());
 

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp;
+
+use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
+use Cake\Routing\Middleware\RoutingMiddleware;
+use Tags\TagsPlugin;
+use Tools\ToolsPlugin;
+
+class Application extends BaseApplication {
+
+	/**
+	 * @param string $configDir Config directory.
+	 */
+	public function __construct(string $configDir) {
+		parent::__construct($configDir);
+
+		$this->addPlugin(new TagsPlugin());
+		$this->addPlugin(new ToolsPlugin());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function bootstrap(): void {
+	}
+
+	/**
+	 * @param \Cake\Http\MiddlewareQueue $middlewareQueue Middleware queue.
+	 * @return \Cake\Http\MiddlewareQueue
+	 */
+	public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue {
+		return $middlewareQueue->add(new RoutingMiddleware($this));
+	}
+
+}


### PR DESCRIPTION
## Summary
- fix the namespace move form inputs and null namespace handling
- prevent namespace moves when slug conflicts already exist in the target namespace
- add regression tests for the admin flow and model logic

## Testing
- composer test
- composer cs-check