### PR TITLE
Normalize admin tag input

### DIFF
--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -111,7 +111,9 @@ class TagsController extends TagsAppController {
 		$tag = $this->Tags->newEmptyEntity();
 
 		if ($this->request->is('post')) {
-			$tag = $this->Tags->patchEntity($tag, $this->request->getData());
+			$data = $this->request->getData();
+			$data['namespace'] = $this->normalizeNamespaceInput($data['namespace'] ?? null);
+			$tag = $this->Tags->patchEntity($tag, $data);
 			if ($this->Tags->save($tag)) {
 				$this->Flash->success(__d('tags', 'The tag has been saved.'));
 
@@ -145,7 +147,9 @@ class TagsController extends TagsAppController {
 		$tag = $this->Tags->get($id);
 
 		if ($this->request->is(['patch', 'post', 'put'])) {
-			$tag = $this->Tags->patchEntity($tag, $this->request->getData());
+			$data = $this->request->getData();
+			$data['namespace'] = $this->normalizeNamespaceInput($data['namespace'] ?? null);
+			$tag = $this->Tags->patchEntity($tag, $data);
 			if ($this->Tags->save($tag)) {
 				$this->Flash->success(__d('tags', 'The tag has been saved.'));
 

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -98,7 +98,11 @@ class TagsTable extends Table {
 	 * @return void
 	 */
 	public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {
-		if (isset($data['label']) && isset($data['slug']) && $data['slug'] === 0) {
+		if (isset($data['namespace']) && $data['namespace'] === '') {
+			$data['namespace'] = null;
+		}
+
+		if (isset($data['label']) && array_key_exists('slug', (array)$data) && ($data['slug'] === '' || $data['slug'] === 0 || $data['slug'] === null)) {
 			$data['slug'] = $this->slug($data['label']);
 		}
 	}

--- a/tests/TestCase/Controller/Admin/TagsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TagsControllerTest.php
@@ -96,4 +96,27 @@ class TagsControllerTest extends TestCase {
 		$this->assertSame(['color', 'dark-color'], $result);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testAddAutoGeneratesSlugAndNormalizesBlankNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+
+		$this->post('/admin/tags/tags/add', [
+			'label' => 'Fresh Tag',
+			'slug' => '',
+			'namespace' => '',
+			'color' => '#123456',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags');
+
+		$tag = $tagsTable->find()
+			->where(['slug' => 'fresh-tag'])
+			->firstOrFail();
+
+		$this->assertNull($tag->namespace);
+		$this->assertSame('#123456', $tag->color);
+	}
+
 }

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -130,6 +130,21 @@ class TagsTableTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testBeforeMarshalAutoGeneratesSlugAndNormalizesNamespace(): void {
+		$tag = $this->Tags->newEntity([
+			'label' => 'Auto Slug Test',
+			'slug' => '',
+			'namespace' => '',
+		]);
+
+		$this->assertEmpty($tag->getErrors());
+		$this->assertSame('auto-slug-test', $tag->slug);
+		$this->assertNull($tag->namespace);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testMoveNamespace(): void {
 		$count = $this->Tags->moveNamespace(null, 'palette');
 


### PR DESCRIPTION
## Summary
- auto-generate slugs when the admin add form leaves slug empty
- normalize blank namespaces to null in admin tag create/edit flows
- add regression coverage for the model and admin controller paths

## Testing
- composer test
- composer cs-check