### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/Tags/add.php
+++ b/templates/Admin/Tags/add.php
@@ -4,6 +4,7 @@
  * @var \Tags\Model\Entity\Tag $tag
  * @var array $namespaces
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <h1 class="mb-4">
@@ -94,7 +95,7 @@
 </div>
 
 <?php $this->append('script'); ?>
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var colorPicker = document.getElementById('color');
 	var colorText = document.getElementById('color-text');

--- a/templates/Admin/Tags/change_namespace.php
+++ b/templates/Admin/Tags/change_namespace.php
@@ -3,6 +3,7 @@
  * @var \App\View\AppView $this
  * @var array $namespaces
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <h1 class="mb-4">
@@ -116,7 +117,7 @@
 <?php endif; ?>
 
 <?php $this->append('script'); ?>
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var select = document.getElementById('to-namespace-select');
 	var input = document.getElementById('to-namespace-new');

--- a/templates/Admin/Tags/edit.php
+++ b/templates/Admin/Tags/edit.php
@@ -4,6 +4,7 @@
  * @var \Tags\Model\Entity\Tag $tag
  * @var array $namespaces
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <h1 class="mb-4">
@@ -93,7 +94,7 @@
 </div>
 
 <?php $this->append('script'); ?>
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var colorPicker = document.getElementById('color-picker');
 	var colorText = document.getElementById('color-text');

--- a/templates/Admin/Tags/index.php
+++ b/templates/Admin/Tags/index.php
@@ -114,15 +114,17 @@
 							<a href="<?= $this->Url->build(['action' => 'edit', $tag->id]) ?>" class="btn btn-outline-secondary" title="<?= __d('tags', 'Edit') ?>">
 								<i class="fas fa-edit"></i>
 							</a>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-trash"></i>',
 								['action' => 'delete', $tag->id],
 								[
 									'class' => 'btn btn-outline-danger',
 									'escapeTitle' => false,
-									'confirm' => __d('tags', 'Delete tag "{0}"? This will also remove all associations.', $tag->label),
 									'title' => __d('tags', 'Delete'),
-									'block' => true,
+									'form' => [
+										'class' => 'd-inline',
+										'data-confirm-message' => __d('tags', 'Delete tag "{0}"? This will also remove all associations.', $tag->label),
+									],
 								],
 							) ?>
 						</div>

--- a/templates/Admin/Tags/merge.php
+++ b/templates/Admin/Tags/merge.php
@@ -4,6 +4,7 @@
  * @var array<\Tags\Model\Entity\Tag> $tags
  * @var array $tagsByNamespace
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <h1 class="mb-4">
@@ -81,7 +82,7 @@
 </div>
 
 <?php $this->append('script'); ?>
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var sourceSelect = document.getElementById('source');
 	var targetSelect = document.getElementById('target');

--- a/templates/Admin/Tags/orphaned.php
+++ b/templates/Admin/Tags/orphaned.php
@@ -24,14 +24,16 @@
 			<i class="fas fa-list me-2"></i>
 			<?= __d('tags', 'Orphaned Tags List') ?>
 		</span>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-trash-alt me-1"></i>' . __d('tags', 'Delete All Orphaned Tags'),
 			['action' => 'deleteOrphaned'],
 			[
 				'class' => 'btn btn-danger btn-sm',
 				'escapeTitle' => false,
-				'confirm' => __d('tags', 'Are you sure you want to delete all {0} orphaned tags? This cannot be undone.', $orphanedCount),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __d('tags', 'Are you sure you want to delete all {0} orphaned tags? This cannot be undone.', $orphanedCount),
+				],
 			]
 		) ?>
 	</div>
@@ -71,15 +73,17 @@
 							<a href="<?= $this->Url->build(['action' => 'edit', $tag->id]) ?>" class="btn btn-outline-primary" title="<?= __d('tags', 'Edit') ?>">
 								<i class="fas fa-edit"></i>
 							</a>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-trash-alt"></i>',
 								['action' => 'delete', $tag->id],
 								[
 									'class' => 'btn btn-outline-danger',
 									'escapeTitle' => false,
-									'confirm' => __d('tags', 'Are you sure you want to delete "{0}"?', $tag->label),
 									'title' => __d('tags', 'Delete'),
-									'block' => true,
+									'form' => [
+										'class' => 'd-inline',
+										'data-confirm-message' => __d('tags', 'Are you sure you want to delete "{0}"?', $tag->label),
+									],
 								]
 							) ?>
 						</div>

--- a/templates/Admin/Tags/view.php
+++ b/templates/Admin/Tags/view.php
@@ -17,14 +17,16 @@
 			<i class="fas fa-edit me-1"></i>
 			<?= __d('tags', 'Edit') ?>
 		</a>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-trash me-1"></i>' . __d('tags', 'Delete'),
 			['action' => 'delete', $tag->id],
 			[
 				'class' => 'btn btn-outline-danger',
 				'escapeTitle' => false,
-				'confirm' => __d('tags', 'Delete tag "{0}"? This will also remove all associations.', $tag->label),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __d('tags', 'Delete tag "{0}"? This will also remove all associations.', $tag->label),
+				],
 			],
 		) ?>
 	</div>

--- a/templates/Admin/TagsDashboard/index.php
+++ b/templates/Admin/TagsDashboard/index.php
@@ -80,13 +80,15 @@
 				<small class="text-muted d-block mt-1"><?= __d('tags', 'Review and remove unused tags') ?></small>
 			</div>
 			<div class="col-md-4">
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-sync-alt me-2"></i>' . __d('tags', 'Recalculate Counters'),
 					['controller' => 'Tags', 'action' => 'recalculateCounters'],
 					[
 						'class' => 'btn btn-outline-info w-100',
 						'escapeTitle' => false,
-						'block' => true,
+						'form' => [
+							'class' => 'd-inline',
+						],
 					]
 				) ?>
 				<small class="text-muted d-block mt-1"><?= __d('tags', 'Fix tag usage counts') ?></small>

--- a/templates/layout/tags.php
+++ b/templates/layout/tags.php
@@ -7,6 +7,7 @@
  *
  * @var \Cake\View\View $this
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -265,7 +266,7 @@
 			</a>
 
 			<!-- Mobile toggle -->
-			<button class="navbar-toggler tags-mobile-toggle d-lg-none" type="button" onclick="document.querySelector('.tags-sidebar').classList.toggle('show')">
+			<button class="navbar-toggler tags-mobile-toggle d-lg-none" type="button" data-tags-sidebar-toggle="1">
 				<i class="fas fa-bars"></i>
 			</button>
 		</div>
@@ -286,6 +287,27 @@
 
 	<!-- Bootstrap JS -->
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+	// Mobile sidebar toggle (CSP-safe replacement for inline onclick)
+	document.querySelectorAll('[data-tags-sidebar-toggle]').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var sidebar = document.querySelector('.tags-sidebar');
+			if (sidebar) {
+				sidebar.classList.toggle('show');
+			}
+		});
+	});
+
+	// Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
+	document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+		form.addEventListener('submit', function(e) {
+			if (!confirm(form.dataset.confirmMessage)) {
+				e.preventDefault();
+			}
+		});
+	});
+	</script>
 
 	<?= $this->fetch('script') ?>
 	<?= $this->fetch('postLink') ?>


### PR DESCRIPTION
## Summary

- Add nonce to inline `<script>` blocks in the admin layout and 4 admin templates.
- Replace the navbar-toggler's inline `onclick` with a data attribute + delegated listener.
- Replace 5 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message`.
- Register the `form[data-confirm-message]` submit delegate in the layout, so every admin page picks it up automatically.

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- **Layout (`templates/layout/tags.php`)**:
  - Replace the mobile navbar-toggler `onclick="document.querySelector('.tags-sidebar').classList.toggle('show')"` with `data-tags-sidebar-toggle="1"` + a delegated click listener.
  - Add a new inline `<script>` block (with nonce) in the layout that hosts the toggle listener plus the `form[data-confirm-message]` submit delegate.
- **Admin templates**: add nonce to 4 existing inline `<script>` blocks (`add.php`, `edit.php`, `merge.php`, `change_namespace.php`).
- **postLink migration**: replace 5 `Form->postLink` calls with `Form->postButton` across `TagsDashboard/index.php`, `Tags/index.php`, `Tags/view.php`, and `Tags/orphaned.php` (2). The confirm strings move to `data-confirm-message` on the form, handled by the layout's delegate.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <button class="navbar-toggler tags-mobile-toggle d-lg-none" type="button" onclick="document.querySelector('.tags-sidebar').classList.toggle('show')">
+ <button class="navbar-toggler tags-mobile-toggle d-lg-none" type="button" data-tags-sidebar-toggle="1">
```

```diff
- <?= $this->Form->postLink('<i class="fas fa-trash"></i>', [...], [
-     'class' => 'btn btn-outline-danger',
-     'escapeTitle' => false,
-     'confirm' => __d('tags', 'Delete tag "{0}"?', $tag->label),
-     'block' => true,
- ]) ?>
+ <?= $this->Form->postButton('<i class="fas fa-trash"></i>', [...], [
+     'class' => 'btn btn-outline-danger',
+     'escapeTitle' => false,
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => __d('tags', 'Delete tag "{0}"?', $tag->label),
+     ],
+ ]) ?>
```

Note: the btn-group layout on `view.php`, `index.php`, and `orphaned.php` continues to work because the postButton form is rendered with `class="d-inline"` inside the existing `.btn-group`.
