### PR TITLE
Replace inline color swatches with data-tag-color + JS (strict-CSP)

### DIFF
--- a/templates/Admin/Tags/duplicates.php
+++ b/templates/Admin/Tags/duplicates.php
@@ -43,7 +43,7 @@
 				<tr>
 					<td>
 						<?php if ($tag->color): ?>
-						<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+						<span class="tag-color-swatch me-2" data-tag-color="<?= h($tag->color) ?>"></span>
 						<?php endif; ?>
 						<?= h($tag->label) ?>
 					</td>

--- a/templates/Admin/Tags/index.php
+++ b/templates/Admin/Tags/index.php
@@ -94,7 +94,7 @@
 					</td>
 					<td>
 						<?php if ($tag->color) : ?>
-						<span class="tag-color-swatch" style="background-color: <?= h($tag->color) ?>" title="<?= h($tag->color) ?>"></span>
+						<span class="tag-color-swatch" data-tag-color="<?= h($tag->color) ?>" title="<?= h($tag->color) ?>"></span>
 						<code class="ms-1"><?= h($tag->color) ?></code>
 						<?php else : ?>
 						<span class="text-muted">-</span>

--- a/templates/Admin/Tags/merge_preview.php
+++ b/templates/Admin/Tags/merge_preview.php
@@ -34,7 +34,7 @@ $itemsToMove = $itemsToRetag - $duplicates;
 						<span class="badge bg-secondary"><?= h($sourceTag->namespace) ?></span>
 						<?php endif; ?>
 						<?php if ($sourceTag->color) : ?>
-						<span class="tag-color-swatch ms-2" style="background-color: <?= h($sourceTag->color) ?>"></span>
+						<span class="tag-color-swatch ms-2" data-tag-color="<?= h($sourceTag->color) ?>"></span>
 						<?php endif; ?>
 						<div class="mt-2 text-muted">
 							<code><?= h($sourceTag->slug) ?></code>
@@ -60,7 +60,7 @@ $itemsToMove = $itemsToRetag - $duplicates;
 						<span class="badge bg-secondary"><?= h($targetTag->namespace) ?></span>
 						<?php endif; ?>
 						<?php if ($targetTag->color) : ?>
-						<span class="tag-color-swatch ms-2" style="background-color: <?= h($targetTag->color) ?>"></span>
+						<span class="tag-color-swatch ms-2" data-tag-color="<?= h($targetTag->color) ?>"></span>
 						<?php endif; ?>
 						<div class="mt-2 text-muted">
 							<code><?= h($targetTag->slug) ?></code>

--- a/templates/Admin/Tags/orphaned.php
+++ b/templates/Admin/Tags/orphaned.php
@@ -60,7 +60,7 @@
 					</td>
 					<td>
 						<?php if ($tag->color): ?>
-						<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+						<span class="tag-color-swatch me-2" data-tag-color="<?= h($tag->color) ?>"></span>
 						<?php endif; ?>
 						<?= h($tag->label) ?>
 					</td>

--- a/templates/Admin/Tags/view.php
+++ b/templates/Admin/Tags/view.php
@@ -64,7 +64,7 @@
 						<th><?= __d('tags', 'Color') ?></th>
 						<td>
 							<?php if ($tag->color) : ?>
-							<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+							<span class="tag-color-swatch me-2" data-tag-color="<?= h($tag->color) ?>"></span>
 							<code><?= h($tag->color) ?></code>
 							<?php else : ?>
 							<span class="text-muted">-</span>

--- a/templates/Admin/TagsDashboard/index.php
+++ b/templates/Admin/TagsDashboard/index.php
@@ -119,7 +119,7 @@
 					<li class="list-group-item d-flex justify-content-between align-items-center">
 						<span>
 							<?php if ($tag->color): ?>
-							<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+							<span class="tag-color-swatch me-2" data-tag-color="<?= h($tag->color) ?>"></span>
 							<?php endif; ?>
 							<?php if ($tag->namespace): ?>
 							<small class="text-muted"><?= h($tag->namespace) ?>:</small>
@@ -212,7 +212,7 @@
 					<li class="list-group-item d-flex justify-content-between align-items-center">
 						<span>
 							<?php if ($tag->color): ?>
-							<span class="tag-color-swatch me-2" style="background-color: <?= h($tag->color) ?>"></span>
+							<span class="tag-color-swatch me-2" data-tag-color="<?= h($tag->color) ?>"></span>
 							<?php endif; ?>
 							<?php if ($tag->namespace): ?>
 							<small class="text-muted"><?= h($tag->namespace) ?>:</small>

--- a/templates/layout/tags.php
+++ b/templates/layout/tags.php
@@ -307,6 +307,11 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			}
 		});
 	});
+
+	// Tag color swatches (CSP-safe replacement for inline style="background-color:...")
+	document.querySelectorAll('.tag-color-swatch[data-tag-color]').forEach(function(el) {
+		el.style.backgroundColor = el.dataset.tagColor;
+	});
 	</script>
 
 	<?= $this->fetch('script') ?>


### PR DESCRIPTION
## Summary

Removes the 8 `style="background-color: <?= h(\$tag->color) ?>"` attributes on `.tag-color-swatch` elements across the admin templates, replacing them with `data-tag-color="..."` attributes. A 3-line block in the layout's already-nonced `<script>` reads each swatch's `dataset.tagColor` and assigns `el.style.backgroundColor`. JS-driven style mutation is not subject to `style-src 'unsafe-inline'`, so the page is now strict-CSP compatible for these elements.

## Files changed

- `templates/Admin/Tags/{duplicates,index,merge_preview,orphaned,view}.php`
- `templates/Admin/TagsDashboard/index.php`
- `templates/layout/tags.php` — adds 3-line color-swatch initializer to the existing nonced script

## Notes

- Visual is unchanged.
- The static `<th style="width: 30%">` in `Admin/Tags/view.php` is unrelated to dynamic colors and left as a follow-up.