### PR TITLE
Drop last static `<th style="width:30%">` for strict-CSP

### DIFF
--- a/templates/Admin/Tags/view.php
+++ b/templates/Admin/Tags/view.php
@@ -43,7 +43,7 @@
 			<div class="card-body">
 				<table class="table table-borderless mb-0">
 					<tr>
-						<th style="width: 30%"><?= __d('tags', 'Label') ?></th>
+						<th class="tags-col-w-30"><?= __d('tags', 'Label') ?></th>
 						<td><strong><?= h($tag->label) ?></strong></td>
 					</tr>
 					<tr>

--- a/templates/layout/tags.php
+++ b/templates/layout/tags.php
@@ -205,6 +205,9 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			display: inline-block;
 		}
 
+		/* Column-width utility (replaces inline `<th style="width:30%">`). */
+		.tags-col-w-30 { width: 30%; }
+
 		/* Alerts/Flash */
 		.tags-flash {
 			border: none;


### PR DESCRIPTION
Follow-up to #55: removes the single leftover inline `style="width:30%"` in `Admin/Tags/view.php` by introducing a `.tags-col-w-30` class in the layout's existing `<style>` block. Templates now contain zero inline `style=` attributes.