### PR TITLE
v3.0.0: named-arg finders, type tightening, config cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Make tagging of entities a piece of cake.
 
 This branch is for **CakePHP 5.1+**. For details see [version map](https://github.com/dereuromark/cakephp-tags/wiki#cakephp-version-map).
 
+Upgrading from 2.x? See [UPGRADE.md](UPGRADE.md) for the v3 migration notes.
+
 ## Install
 
 Using Composer:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,101 @@
+# Upgrading from 2.x to 3.0
+
+cakephp-tags 3.0 is a breaking release focused on modernizing the finder API
+and removing one dead config shape. Requirements are unchanged: PHP 8.2+,
+CakePHP 5.1+.
+
+## Automated migration
+
+Most call-site changes can be applied with the cakephp/upgrade rector:
+
+```
+composer require --dev cakephp/upgrade
+vendor/bin/cake upgrade rector --rules=named_arguments src/
+```
+
+What rector cannot rewrite is documented inline below.
+
+## Breaking changes
+
+### 1. `find('tagged')` — call-site key collapsed to `value`
+
+The dynamic call-site key (`slug` or `label`, mirroring the `finderField`
+config) has been replaced by a single fixed parameter named `value`. The
+`finderField` config still controls which Tags column is matched against,
+so only the call-site shape changes.
+
+```php
+// Before
+$query->find('tagged', ['slug'  => 'example-tag']);
+$query->find('tagged', ['label' => ['one', 'two']]);
+
+// After
+$query->find('tagged', value: 'example-tag');
+$query->find('tagged', value: ['one', 'two']);
+```
+
+Rector will not rewrite this — manual change required.
+
+### 2. `find('untagged')` — named `counterField` argument
+
+```php
+// Before
+$query->find('untagged', ['counterField' => 'my_count']);
+
+// After
+$query->find('untagged', counterField: 'my_count');
+```
+
+The `counterField => false` overload that previously forced a live pivot
+lookup has been removed. The live path is auto-selected when no counter
+cache field is configured, so the explicit override turned out to be
+redundant. If you actually need to force a live lookup despite a counter
+cache being configured, please open an issue.
+
+### 3. Method rename: `findByTag` → `findTagged`
+
+The method backing the `tagged` finder alias has been renamed so it matches
+its alias. Calls through `$query->find('tagged', ...)` are unaffected.
+Direct method calls must be renamed:
+
+```php
+// Before
+$table->findByTag($query, ['slug' => 'foo']);
+
+// After
+$table->findTagged($query, value: 'foo');
+```
+
+### 4. `taggedCounter` config — flat shape only
+
+The nested `['field' => ['conditions' => []]]` shape was a no-op (its
+per-field `conditions` value was overwritten internally) and has been
+removed. Accepted shapes after 3.0:
+
+```php
+// All still work
+'taggedCounter' => false,                          // disable counter cache
+'taggedCounter' => 'tag_count',                    // single field shorthand
+'taggedCounter' => ['tag_count', 'other_count'],   // list of fields
+
+// No longer supported — unwrap to the flat list above
+'taggedCounter' => ['tag_count' => ['conditions' => []]],
+```
+
+If you used the nested form, just unwrap to the flat list.
+
+### 5. `prepareTagsForOutput()` split into strict-typed siblings
+
+Two new strict-typed methods are available; the original method is kept as
+a dispatcher and keeps its `array|string` return type, so direct callers
+are unaffected.
+
+```php
+$behavior->prepareTagsForOutputArray($data);   // : array
+$behavior->prepareTagsForOutputString($data);  // : string
+```
+
+## Non-breaking changes
+
+- `normalizeTags()` now declares `array|string $tags` natively (was
+  docblock-only). No behavior change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ They can also be combined/stacked with other custom finders, of course.
 
 #### Tagged
 ```php
-$taggedRecords = $this->Records->find('tagged', ...['tag' => 'tag-slug']);
+$taggedRecords = $this->Records->find('tagged', value: 'tag-slug');
 ```
 It also accepts an array here to match any of these tags given.
 
@@ -309,8 +309,7 @@ $searchManager
     ...
     ->callback('tag', [
         'callback' => function (SelectQuery $query, array $args, $manager): bool {
-            // Here you would have to remap $args if key isn't the expected "tag"
-            $query->find('tagged', ...$args);
+            $query->find('tagged', value: $args['tag']);
 
             return true;
         },
@@ -322,10 +321,10 @@ $searchManager
 Using `orSeparator`/`andSeparator` config, one can also filter by multiple tags at once:
 ```php
 // Records that have either "one" or "two" tag
-$query->find('tagged', ...['slug' => 'one,two']);
+$query->find('tagged', value: 'one,two');
 
 // Records that have both "one" and "two" tag
-$query->find('tagged', ...['slug' => 'one+two']);
+$query->find('tagged', value: 'one+two');
 ```
 
 For this to be used inside Search plugin, you would usually generate URLs like this:
@@ -351,7 +350,7 @@ Then you just have to switch the query inside the callback in the case of `-1`:
         if ($args['tag'] === '-1') {
             $query->find('untagged');
         } else {
-            $query->find('tagged', ...$args);
+            $query->find('tagged', value: $args['tag']);
         }
 
         return true;

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -255,12 +255,12 @@ class TagsController extends TagsAppController {
 
 		// Count items that will be re-tagged
 		$itemsToRetag = $taggedTable->find()
-			->where(['tag_id' => $sourceId])
+			->where(['Tagged.tag_id' => $sourceId])
 			->count();
 
 		// Count duplicates (items that have both tags)
 		$duplicates = $taggedTable->find()
-			->where(['tag_id' => $sourceId])
+			->where(['Tagged.tag_id' => $sourceId])
 			->innerJoin(
 				['t2' => 'tags_tagged'],
 				[
@@ -385,7 +385,7 @@ class TagsController extends TagsAppController {
 		}
 
 		// Header row
-		fputcsv($output, ['id', 'namespace', 'slug', 'label', 'color', 'counter', 'created', 'modified']);
+		fputcsv($output, ['id', 'namespace', 'slug', 'label', 'color', 'counter', 'created', 'modified'], ',', '"', '\\');
 
 		// Data rows
 		foreach ($tags as $tag) {
@@ -398,7 +398,7 @@ class TagsController extends TagsAppController {
 				$tag->counter,
 				$tag->created->format('Y-m-d H:i:s'),
 				$tag->modified->format('Y-m-d H:i:s'),
-			]);
+			], ',', '"', '\\');
 		}
 
 		rewind($output);

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -40,11 +40,7 @@ class TagBehavior extends Behavior {
 		'taggedAssoc' => [
 			'className' => 'Tags.Tagged',
 		],
-		'taggedCounter' => [
-			'tag_count' => [
-				'conditions' => [],
-			],
-		],
+		'taggedCounter' => ['tag_count'],
 		'implementedEvents' => [
 			'Model.beforeMarshal' => 'beforeMarshal',
 			'Model.beforeFind' => 'beforeFind',
@@ -329,15 +325,23 @@ class TagBehavior extends Behavior {
 	}
 
 	/**
-	 * @param array|string $config
-	 * @return array
+	 * Normalizes the user-facing taggedCounter config (false, string, or
+	 * list of field names) to the map shape expected by CounterCacheBehavior.
+	 *
+	 * @param array<string>|string $config
+	 * @return array<string, array<string, mixed>>
 	 */
-	protected function _getTaggedCounterConfig($config): array {
-		if (!is_array($config)) {
+	protected function _getTaggedCounterConfig(array|string $config): array {
+		if (is_string($config)) {
 			return [$config => ['conditions' => []]];
 		}
 
-		return $config;
+		$normalized = [];
+		foreach ($config as $field) {
+			$normalized[$field] = ['conditions' => []];
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -341,37 +341,27 @@ class TagBehavior extends Behavior {
 	}
 
 	/**
-	 * Customer finder method using slug/tag lookup.
+	 * Custom finder for tagged records.
 	 *
-	 * It accepts both string or array (multiple strings) for the slug/tag value(s).
-	 *
-	 * {finderField} via config can be either 'slug' or 'label' of Tags table. Defaults to slug.
+	 * Accepts a single value or a list of values. The configured `finderField`
+	 * (defaulting to `slug`) determines which Tags column is matched against.
 	 *
 	 * Usage:
-	 *   $query->find('tagged', ...['{finderField}' => 'example-tag']);
-	 * or:
-	 *   $query->find('tagged', ...['{finderField}' => ['one', 'two']);
+	 *   $query->find('tagged', value: 'example-tag');
+	 *   $query->find('tagged', value: ['one', 'two']);
 	 *
 	 * @param \Cake\ORM\Query\SelectQuery $query
-	 * @param array<string, mixed> $options
-	 * @throws \RuntimeException
+	 * @param array<string>|string $value
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
-	public function findTagged(SelectQuery $query, array $options): SelectQuery {
-		$finderField = $optionsKey = $this->getConfig('finderField');
-		if (!$finderField) {
-			$finderField = $optionsKey = 'slug';
-		}
-
-		if (!isset($options[$optionsKey])) {
-			throw new RuntimeException(sprintf('Expected key `%s` not present in find(\'tagged\') options argument.', $optionsKey));
-		}
-		$filterValue = $options[$optionsKey];
-		if (!$filterValue) {
+	public function findTagged(SelectQuery $query, array|string $value): SelectQuery {
+		if (!$value) {
 			return $query;
 		}
 
-		$subQuery = $this->buildQuerySnippet($filterValue, $finderField);
+		$finderField = $this->getConfig('finderField') ?: 'slug';
+
+		$subQuery = $this->buildQuerySnippet($value, $finderField);
 		if (is_string($subQuery)) {
 			$query->matching($this->getConfig('tagsAlias'), function (QueryInterface $q) use ($finderField, $subQuery) {
 				$key = $this->getConfig('tagsAlias') . '.' . $finderField;

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -380,31 +380,31 @@ class TagBehavior extends Behavior {
 	}
 
 	/**
-	 * Customer finder method.
+	 * Custom finder for untagged records.
 	 *
 	 * Usage:
 	 *   $query->find('untagged');
 	 *
-	 * Define a field if you have multiple counter cache fields set up:
-	 *   $query->find('untagged', ...['counterField' => 'my_tag_count']);
-	 * Otherwise it will fallback to the first in the list.
+	 * Pass an explicit counter field if multiple are configured:
+	 *   $query->find('untagged', counterField: 'my_tag_count');
 	 *
-	 * Set 'counterField' to false to do a live lookup in the pivot table.
-	 * It will automatically do the live lookup if you do not have any counter cache fields.
+	 * When no counter cache field is configured (or none is passed and
+	 * none is found on the table), a live lookup against the pivot table
+	 * is performed automatically.
 	 *
 	 * @param \Cake\ORM\Query\SelectQuery $query
-	 * @param array<string, mixed> $options
+	 * @param string|null $counterField
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
-	public function findUntagged(SelectQuery $query, array $options): SelectQuery {
-		$taggedCounters = $this->getConfig('taggedCounter') ? array_keys($this->_getTaggedCounterConfig($this->getConfig('taggedCounter'))) : [];
-		$options += [
-			'counterField' => $taggedCounters ? reset($taggedCounters) : null,
-		];
+	public function findUntagged(SelectQuery $query, ?string $counterField = null): SelectQuery {
+		if ($counterField === null) {
+			$taggedCounters = $this->getConfig('taggedCounter') ? array_keys($this->_getTaggedCounterConfig($this->getConfig('taggedCounter'))) : [];
+			$counterField = $taggedCounters ? reset($taggedCounters) : null;
+		}
 
 		$modelAlias = $this->getConfig('fkModelAlias') ?: $this->_table->getAlias();
-		if ($options['counterField']) {
-			return $query->where([$this->_table->getAlias() . '.' . $options['counterField'] => 0]);
+		if ($counterField !== null) {
+			return $query->where([$this->_table->getAlias() . '.' . $counterField => 0]);
 		}
 
 		$foreignKey = $this->getConfig('tagsAssoc.foreignKey');

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -189,13 +189,29 @@ class TagBehavior extends Behavior {
 	}
 
 	/**
-	 * Generates comma-delimited string of tag names from tag array(), needed for
-	 * initialization of data for text input
+	 * Generates tag output for the configured strategy ('array' or 'string').
 	 *
-	 * @param array $data Tag data array to convert to string.
-	 * @return array|string
+	 * Dispatches to {@see prepareTagsForOutputArray()} or
+	 * {@see prepareTagsForOutputString()} based on the `strategy` config.
+	 *
+	 * @param array $data Tag data array to convert.
+	 * @return array<string>|string
 	 */
-	public function prepareTagsForOutput(array $data) {
+	public function prepareTagsForOutput(array $data): array|string {
+		if ($this->_config['strategy'] === 'array') {
+			return $this->prepareTagsForOutputArray($data);
+		}
+
+		return $this->prepareTagsForOutputString($data);
+	}
+
+	/**
+	 * Returns tag labels (with namespace prefix when configured) as a list.
+	 *
+	 * @param array $data Tag data array.
+	 * @return array<string>
+	 */
+	public function prepareTagsForOutputArray(array $data): array {
 		$tags = [];
 
 		foreach ($data as $tag) {
@@ -206,11 +222,17 @@ class TagBehavior extends Behavior {
 			}
 		}
 
-		if ($this->_config['strategy'] === 'array') {
-			return $tags;
-		}
+		return $tags;
+	}
 
-		return implode($this->_config['delimiter'] . ' ', $tags);
+	/**
+	 * Returns tag labels joined by the configured delimiter as a single string.
+	 *
+	 * @param array $data Tag data array.
+	 * @return string
+	 */
+	public function prepareTagsForOutputString(array $data): string {
+		return implode($this->_config['delimiter'] . ' ', $this->prepareTagsForOutputArray($data));
 	}
 
 	/**
@@ -428,7 +450,7 @@ class TagBehavior extends Behavior {
 	 * @param array<string>|string $tags List of tags as an array or a delimited string (comma by default).
 	 * @return array Normalized tags valid to be marshaled.
 	 */
-	public function normalizeTags($tags): array {
+	public function normalizeTags(array|string $tags): array {
 		if (is_string($tags)) {
 			$tags = explode($this->getConfig('delimiter'), $tags);
 		}

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -54,7 +54,7 @@ class TagBehavior extends Behavior {
 			'normalizeTags' => 'normalizeTags',
 		],
 		'implementedFinders' => [
-			'tagged' => 'findByTag',
+			'tagged' => 'findTagged',
 			'untagged' => 'findUntagged',
 		],
 		'finderField' => null, // Set to a specific field, e.g. `tag` for using tag name, defaults to `slug`
@@ -357,7 +357,7 @@ class TagBehavior extends Behavior {
 	 * @throws \RuntimeException
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
-	public function findByTag(SelectQuery $query, array $options): SelectQuery {
+	public function findTagged(SelectQuery $query, array $options): SelectQuery {
 		$finderField = $optionsKey = $this->getConfig('finderField');
 		if (!$finderField) {
 			$finderField = $optionsKey = 'slug';

--- a/tests/TestCase/Controller/Admin/TagsAppControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TagsAppControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Test\TestCase\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class TagsAppControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Tags.Tags',
+		'plugin.Tags.Tagged',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->disableErrorHandlerMiddleware();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Configure::delete('Tags.standalone');
+		Configure::delete('Tags.adminLayout');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDefaultLayoutUsesPluginLayout(): void {
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Tags Admin');
+		$this->assertResponseContains('Bootstrap');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCustomLayoutFromConfig(): void {
+		Configure::write('Tags.adminLayout', 'Tags.tags');
+
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Tags Admin');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testStandaloneMode(): void {
+		Configure::write('Tags.standalone', true);
+
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+	}
+
+}

--- a/tests/TestCase/Controller/Admin/TagsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TagsControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tags\Test\TestCase\Controller\Admin;
 
+use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -16,6 +17,7 @@ class TagsControllerTest extends TestCase {
 	 */
 	protected array $fixtures = [
 		'plugin.Tags.Tags',
+		'plugin.Tags.Tagged',
 	];
 
 	/**
@@ -25,6 +27,502 @@ class TagsControllerTest extends TestCase {
 		parent::setUp();
 
 		$this->disableErrorHandlerMiddleware();
+		$this->enableRetainFlashMessages();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndex(): void {
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Color');
+		$this->assertResponseContains('Dark Color');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexFilteredByNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'accent',
+			'label' => 'Accent',
+		]));
+
+		$this->get('/admin/tags/tags?namespace=palette');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Accent');
+		$this->assertResponseNotContains('Dark Color');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexFilteredByNoneNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'accent',
+			'label' => 'Accent Tag',
+		]));
+
+		$this->get('/admin/tags/tags?namespace=__none__');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Color');
+		$this->assertResponseNotContains('Accent Tag');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexFilteredByOrphaned(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'unused-orphan',
+			'label' => 'Unused Orphan',
+		]));
+
+		$this->get('/admin/tags/tags?orphaned=1');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Unused Orphan');
+		$this->assertResponseNotContains('<strong>Color</strong>');
+		$this->assertResponseNotContains('<strong>Dark Color</strong>');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexFilteredBySearch(): void {
+		$this->get('/admin/tags/tags?search=dark');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Dark Color');
+		$this->assertResponseNotContains('<strong>Color</strong>');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testView(): void {
+		$this->get('/admin/tags/tags/view/1');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Color');
+		$this->assertResponseContains('Muffins');
+		$this->assertResponseContains('Buns');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddGet(): void {
+		$this->get('/admin/tags/tags/add');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Add Tag');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddAutoGeneratesSlugAndNormalizesBlankNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+
+		$this->post('/admin/tags/tags/add', [
+			'label' => 'Fresh Tag',
+			'slug' => '',
+			'namespace' => '',
+			'color' => '#123456',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags');
+		$this->assertFlashMessage(__d('tags', 'The tag has been saved.'));
+
+		$tag = $tagsTable->find()
+			->where(['slug' => 'fresh-tag'])
+			->firstOrFail();
+
+		$this->assertNull($tag->namespace);
+		$this->assertSame('#123456', $tag->color);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddNormalizesNoneSentinel(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+
+		$this->post('/admin/tags/tags/add', [
+			'label' => 'Sentinel Tag',
+			'slug' => 'sentinel-tag',
+			'namespace' => '__none__',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags');
+
+		$tag = $tagsTable->find()
+			->where(['slug' => 'sentinel-tag'])
+			->firstOrFail();
+
+		$this->assertNull($tag->namespace);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddInvalid(): void {
+		$this->post('/admin/tags/tags/add', [
+			'label' => '',
+			'slug' => '',
+			'namespace' => '',
+		]);
+
+		$this->assertResponseOk();
+		$this->assertNoRedirect();
+		$this->assertFlashMessage(__d('tags', 'The tag could not be saved. Please try again.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testEditGet(): void {
+		$this->get('/admin/tags/tags/edit/1');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Edit Tag');
+		$this->assertResponseContains('Color');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testEditPost(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+
+		$this->post('/admin/tags/tags/edit/1', [
+			'label' => 'Updated Color',
+			'slug' => 'color',
+			'namespace' => '',
+			'color' => '#ABCDEF',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags');
+		$this->assertFlashMessage(__d('tags', 'The tag has been saved.'));
+
+		$tag = $tagsTable->get(1);
+		$this->assertSame('Updated Color', $tag->label);
+		$this->assertSame('#ABCDEF', $tag->color);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testEditPostInvalid(): void {
+		$this->post('/admin/tags/tags/edit/1', [
+			'label' => '',
+			'slug' => '',
+		]);
+
+		$this->assertResponseOk();
+		$this->assertNoRedirect();
+		$this->assertFlashMessage(__d('tags', 'The tag could not be saved. Please try again.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDelete(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+
+		$this->post('/admin/tags/tags/delete/1');
+
+		$this->assertRedirect('/admin/tags/tags');
+		$this->assertFlashMessage(__d('tags', 'The tag has been deleted.'));
+		$this->assertFalse($tagsTable->exists(['id' => 1]));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteWithGetIsRejected(): void {
+		$this->expectException(MethodNotAllowedException::class);
+
+		$this->get('/admin/tags/tags/delete/1');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMerge(): void {
+		$this->get('/admin/tags/tags/merge');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Merge Tags');
+		$this->assertResponseContains('name="source"');
+		$this->assertResponseContains('name="target"');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMergePreviewMissingSourceRedirects(): void {
+		$this->get('/admin/tags/tags/merge-preview');
+
+		$this->assertRedirect('/admin/tags/tags/merge');
+		$this->assertFlashMessage(__d('tags', 'Please select both source and target tags.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMergePreviewSameSourceTargetRedirects(): void {
+		$this->get('/admin/tags/tags/merge-preview?source=1&target=1');
+
+		$this->assertRedirect('/admin/tags/tags/merge');
+		$this->assertFlashMessage(__d('tags', 'Source and target tags must be different.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMergePreviewDifferentNamespacesRedirects(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$other = $tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'mauve',
+			'label' => 'Mauve',
+		]);
+		$tagsTable->saveOrFail($other);
+
+		$this->get('/admin/tags/tags/merge-preview?source=1&target=' . $other->id);
+
+		$this->assertRedirect('/admin/tags/tags/merge');
+		$this->assertFlashMessage(__d('tags', 'Tags must be in the same namespace to merge.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMergePreviewShowsImpact(): void {
+		$this->get('/admin/tags/tags/merge-preview?source=1&target=2');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Merge Preview');
+		$this->assertResponseContains('Color');
+		$this->assertResponseContains('Dark Color');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMergePreviewExecutesMerge(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$taggedTable = TableRegistry::getTableLocator()->get('Tags.Tagged');
+
+		$this->post('/admin/tags/tags/merge-preview', [
+			'source' => 1,
+			'target' => 2,
+			'confirm' => '1',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags');
+		$this->assertFalse($tagsTable->exists(['id' => 1]));
+		$this->assertSame(0, $taggedTable->find()->where(['tag_id' => 1])->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDuplicates(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'colors',
+			'label' => 'Colors',
+		]));
+
+		$this->get('/admin/tags/tags/duplicates');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Potential Duplicates');
+		$this->assertResponseContains('Color');
+		$this->assertResponseContains('Colors');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDuplicatesEmpty(): void {
+		$taggedTable = TableRegistry::getTableLocator()->get('Tags.Tagged');
+		$taggedTable->deleteAll([]);
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->deleteAll([]);
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'unique-foo',
+			'label' => 'Unique Foo',
+		]));
+
+		$this->get('/admin/tags/tags/duplicates');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('No potential duplicates found');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testOrphaned(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'orphan',
+			'label' => 'Orphan',
+		]));
+
+		$this->get('/admin/tags/tags/orphaned');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Orphan');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testOrphanedEmpty(): void {
+		$this->get('/admin/tags/tags/orphaned');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('No orphaned tags found');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteOrphaned(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'orphan-1',
+			'label' => 'Orphan 1',
+		]));
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'orphan-2',
+			'label' => 'Orphan 2',
+		]));
+
+		$this->post('/admin/tags/tags/delete-orphaned');
+
+		$this->assertRedirect('/admin/tags/tags/orphaned');
+		$this->assertFlashMessage(__d('tags', '{0} orphaned tags have been deleted.', 2));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteOrphanedNoneFound(): void {
+		$this->post('/admin/tags/tags/delete-orphaned');
+
+		$this->assertRedirect('/admin/tags/tags/orphaned');
+		$this->assertFlashMessage(__d('tags', 'No orphaned tags found.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteOrphanedRejectsGet(): void {
+		$this->expectException(MethodNotAllowedException::class);
+
+		$this->get('/admin/tags/tags/delete-orphaned');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecalculateCounters(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		// Manually mess up the counter
+		$tagsTable->updateAll(['counter' => 99], ['id' => 1]);
+
+		$this->post('/admin/tags/tags/recalculate-counters');
+
+		$this->assertRedirect('/admin/tags');
+
+		$tag = $tagsTable->get(1);
+		$this->assertSame(3, $tag->counter);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecalculateCountersAlreadyCorrect(): void {
+		$this->post('/admin/tags/tags/recalculate-counters');
+
+		$this->assertRedirect('/admin/tags');
+		$this->assertFlashMessage(__d('tags', 'All counters are already correct.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecalculateCountersRejectsGet(): void {
+		$this->expectException(MethodNotAllowedException::class);
+
+		$this->get('/admin/tags/tags/recalculate-counters');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testExport(): void {
+		$this->get('/admin/tags/tags/export');
+
+		$this->assertResponseOk();
+		$this->assertContentType('csv');
+		$this->assertHeaderContains('Content-Disposition', 'attachment;');
+		$this->assertHeaderContains('Content-Disposition', '.csv');
+		$this->assertResponseContains('id,namespace,slug,label,color,counter,created,modified');
+		$this->assertResponseContains('color,Color,#FF5733,3');
+		$this->assertResponseContains('dark-color,"Dark Color"');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testExportFilteredByNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'palette-only',
+			'label' => 'Palette Only',
+		]));
+
+		$this->get('/admin/tags/tags/export?namespace=palette');
+
+		$this->assertResponseOk();
+		$this->assertContentType('csv');
+		$this->assertResponseContains('palette-only');
+		$this->assertResponseNotContains('dark-color');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testExportFilteredByEmptyNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'palette-only',
+			'label' => 'Palette Only',
+		]));
+
+		$this->get('/admin/tags/tags/export?namespace=');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('color,Color');
+		$this->assertResponseNotContains('palette-only');
 	}
 
 	/**
@@ -70,6 +568,57 @@ class TagsControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testChangeNamespaceMovesTagsToNewNamespace(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+
+		$this->post('/admin/tags/tags/change-namespace', [
+			'from_namespace' => '__none__',
+			'to_namespace_select' => '',
+			'to_namespace_new' => 'brand-new',
+		]);
+
+		$this->assertRedirect('/admin/tags/tags/change-namespace');
+
+		$result = $tagsTable->find()
+			->where(['namespace' => 'brand-new'])
+			->all()
+			->count();
+		$this->assertSame(2, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testChangeNamespaceSameSourceAndTargetShowsError(): void {
+		$this->post('/admin/tags/tags/change-namespace', [
+			'from_namespace' => '__none__',
+			'to_namespace_select' => '__none__',
+			'to_namespace_new' => '',
+		]);
+
+		$this->assertResponseOk();
+		$this->assertNoRedirect();
+		$this->assertFlashMessage(__d('tags', 'Source and target namespaces must be different.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testChangeNamespaceWithNoSourceTagsShowsInfo(): void {
+		$this->post('/admin/tags/tags/change-namespace', [
+			'from_namespace' => 'does-not-exist',
+			'to_namespace_select' => 'palette',
+			'to_namespace_new' => '',
+		]);
+
+		$this->assertResponseOk();
+		$this->assertNoRedirect();
+		$this->assertFlashMessage(__d('tags', 'No tags found in the source namespace.'));
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testChangeNamespaceRejectsConflicts(): void {
 		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
 		$tagsTable->saveOrFail($tagsTable->newEntity([
@@ -94,29 +643,6 @@ class TagsControllerTest extends TestCase {
 			->extract('slug')
 			->toList();
 		$this->assertSame(['color', 'dark-color'], $result);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testAddAutoGeneratesSlugAndNormalizesBlankNamespace(): void {
-		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
-
-		$this->post('/admin/tags/tags/add', [
-			'label' => 'Fresh Tag',
-			'slug' => '',
-			'namespace' => '',
-			'color' => '#123456',
-		]);
-
-		$this->assertRedirect('/admin/tags/tags');
-
-		$tag = $tagsTable->find()
-			->where(['slug' => 'fresh-tag'])
-			->firstOrFail();
-
-		$this->assertNull($tag->namespace);
-		$this->assertSame('#123456', $tag->color);
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/TagsDashboardControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TagsDashboardControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Tags\Test\TestCase\Controller\Admin;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class TagsDashboardControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Tags.Tags',
+		'plugin.Tags.Tagged',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->disableErrorHandlerMiddleware();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndex(): void {
+		$this->get('/admin/tags');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Dashboard');
+		$this->assertResponseContains('Total Tags');
+		$this->assertResponseContains('Most Used Tags');
+		$this->assertResponseContains('Tags by Namespace');
+		$this->assertResponseContains('Models Using Tags');
+		$this->assertResponseContains('Recently Created Tags');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexRendersStats(): void {
+		$this->get('/admin/tags');
+
+		$this->assertResponseOk();
+		// Two tag fixture rows
+		$this->assertResponseContains('Color');
+		$this->assertResponseContains('Dark Color');
+		// 5 tagged fixture rows across Muffins/Buns
+		$this->assertResponseContains('Muffins');
+		$this->assertResponseContains('Buns');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexWithOrphans(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'unused',
+			'label' => 'Unused',
+		]));
+
+		$this->get('/admin/tags');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Orphaned Tags');
+		$this->assertResponseContains('Unused');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexWithDuplicates(): void {
+		$tagsTable = TableRegistry::getTableLocator()->get('Tags.Tags');
+		// Make sure there's a duplicate group ("color" / "colors")
+		$tagsTable->saveOrFail($tagsTable->newEntity([
+			'slug' => 'colors',
+			'label' => 'Colors',
+		]));
+
+		$this->get('/admin/tags');
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Duplicates');
+	}
+
+}

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -616,7 +616,7 @@ class TagBehaviorTest extends TestCase {
 		$result = $this->Table->Tagged->find('all')->where(['tag_id IN' => Hash::extract($result, '{n}.id')])->toArray();
 		$this->assertCount(2, $result);
 
-		$result = $this->Table->find('tagged', ...['slug' => 'color'])->orderByAsc($this->Table->aliasField('name'))->toArray();
+		$result = $this->Table->find('tagged', value: 'color')->orderByAsc($this->Table->aliasField('name'))->toArray();
 
 		$expected = ['Blue', 'Red'];
 		$this->assertSame($expected, Hash::extract($result, '{n}.name'));
@@ -638,7 +638,7 @@ class TagBehaviorTest extends TestCase {
 		$result = $this->Table->Tagged->find('all')->where(['tag_id IN' => Hash::extract($result, '{n}.id')])->toArray();
 		$this->assertCount(4, $result);
 
-		$result = $this->Table->find('tagged', ...['slug' => 'color,weight'])->orderByAsc($this->Table->aliasField('name'))->toArray();
+		$result = $this->Table->find('tagged', value: 'color,weight')->orderByAsc($this->Table->aliasField('name'))->toArray();
 		$this->assertCount(3, $result);
 
 		$expected = ['Blue', 'Heavy', 'Red'];
@@ -664,7 +664,7 @@ class TagBehaviorTest extends TestCase {
 		$connectionConfig = $this->Table->getConnection()->config();
 		$this->skipIf($connectionConfig['driver'] === Postgres::class, 'Only for MySQL/Sqlite for now');
 
-		$result = $this->Table->find('tagged', ...['slug' => 'color+weight'])->orderByAsc($this->Table->aliasField('name'))->toArray();
+		$result = $this->Table->find('tagged', value: 'color+weight')->orderByAsc($this->Table->aliasField('name'))->toArray();
 
 		$expected = ['Heavy'];
 		$this->assertSame($expected, Hash::extract($result, '{n}.name'));
@@ -682,7 +682,7 @@ class TagBehaviorTest extends TestCase {
 		$tag = $this->Table->Tags->newEntity($tag);
 		$this->Table->Tags->save($tag);
 
-		$result = $this->Table->find('tagged', ...['label' => 'Color'])->orderByAsc($this->Table->aliasField('name'))->toArray();
+		$result = $this->Table->find('tagged', value: 'Color')->orderByAsc($this->Table->aliasField('name'))->toArray();
 
 		$expected = ['Blue', 'Red'];
 		$this->assertSame($expected, Hash::extract($result, '{n}.name'));
@@ -704,7 +704,7 @@ class TagBehaviorTest extends TestCase {
 		$tag = $this->Table->Tags->newEntity($tag);
 		$this->Table->Tags->save($tag);
 
-		$result = $this->Table->find('tagged', ...['slug' => ['color', 'beautiful']])->orderByAsc($this->Table->aliasField('name'))->toArray();
+		$result = $this->Table->find('tagged', value: ['color', 'beautiful'])->orderByAsc($this->Table->aliasField('name'))->toArray();
 
 		$expected = ['Blue', 'Red', 'Shiny'];
 		$this->assertSame($expected, Hash::extract($result, '{n}.name'));

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -565,9 +565,7 @@ class TagBehaviorTest extends TestCase {
 		$this->expectExceptionMessage('Field "non_existent" does not exist in table "buns"');
 
 		$table->addBehavior('Tags.Tag', [
-			'taggedCounter' => [
-				'non_existent' => [],
-			],
+			'taggedCounter' => ['non_existent'],
 		]);
 	}
 

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -179,6 +179,185 @@ class TagsTableTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testFindDuplicatesByPluralSuffix(): void {
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'colors',
+			'label' => 'Colors',
+		]));
+
+		$groups = $this->Tags->findDuplicates();
+
+		$this->assertCount(1, $groups);
+		$this->assertCount(2, $groups[0]);
+		$slugs = array_map(fn ($t) => $t->slug, $groups[0]);
+		sort($slugs);
+		$this->assertSame(['color', 'colors'], $slugs);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindDuplicatesByLevenshtein(): void {
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'colur',
+			'label' => 'Colur',
+		]));
+
+		$groups = $this->Tags->findDuplicates();
+		$this->assertNotEmpty($groups);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindDuplicatesIgnoresAcrossNamespaces(): void {
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'color',
+			'label' => 'Color In Palette',
+		]));
+
+		$groups = $this->Tags->findDuplicates();
+		$this->assertSame([], $groups);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindDuplicatesNamespaceFilter(): void {
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'color',
+			'label' => 'Color In Palette',
+		]));
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'colors',
+			'label' => 'Colors In Palette',
+		]));
+
+		$groups = $this->Tags->findDuplicates('palette');
+		$this->assertCount(1, $groups);
+		$this->assertCount(2, $groups[0]);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindDuplicatesNoneWhenAllUnique(): void {
+		$this->Tags->deleteAll([]);
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'apple',
+			'label' => 'Apple',
+		]));
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'zebra',
+			'label' => 'Zebra',
+		]));
+
+		$this->assertSame([], $this->Tags->findDuplicates());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteOrphaned(): void {
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'orphan-1',
+			'label' => 'Orphan 1',
+		]));
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'orphan-2',
+			'label' => 'Orphan 2',
+		]));
+
+		$count = $this->Tags->deleteOrphaned();
+		$this->assertSame(2, $count);
+		$this->assertFalse($this->Tags->exists(['slug' => 'orphan-1']));
+		$this->assertTrue($this->Tags->exists(['slug' => 'color']));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteOrphanedWithNamespace(): void {
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'orphan-palette',
+			'label' => 'Orphan Palette',
+		]));
+		$this->Tags->saveOrFail($this->Tags->newEntity([
+			'slug' => 'orphan-global',
+			'label' => 'Orphan Global',
+		]));
+
+		$count = $this->Tags->deleteOrphaned('palette');
+		$this->assertSame(1, $count);
+		$this->assertFalse($this->Tags->exists(['slug' => 'orphan-palette']));
+		$this->assertTrue($this->Tags->exists(['slug' => 'orphan-global']));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecalculateCounters(): void {
+		$this->Tags->updateAll(['counter' => 99], ['id' => 1]);
+		$this->Tags->updateAll(['counter' => 0], ['id' => 2]);
+
+		$updated = $this->Tags->recalculateCounters();
+		$this->assertSame(2, $updated);
+
+		$this->assertSame(3, $this->Tags->get(1)->counter);
+		$this->assertSame(2, $this->Tags->get(2)->counter);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecalculateCountersWhenAlreadyCorrect(): void {
+		$updated = $this->Tags->recalculateCounters();
+		$this->assertSame(0, $updated);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMerge(): void {
+		$taggedTable = TableRegistry::getTableLocator()->get('Tags.Tagged');
+
+		$result = $this->Tags->merge(2, 1);
+		$this->assertTrue($result);
+
+		$this->assertFalse($this->Tags->exists(['id' => 2]));
+		// Source had 2 associations (Muffins:1, Buns:2). One was a duplicate (Muffins:1 has both tags 1 and 2),
+		// so the duplicate is deleted, the unique Buns:2 is moved to tag 1.
+		// Original tag 1 had 3 associations + 1 moved = 4
+		$tag1 = $this->Tags->get(1);
+		$this->assertSame(4, $tag1->counter);
+		$this->assertSame(0, $taggedTable->find()->where(['tag_id' => 2])->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMergeReturnsFalseOnNamespaceMismatch(): void {
+		$other = $this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'palette-color',
+			'label' => 'Palette Color',
+		]);
+		$this->Tags->saveOrFail($other);
+
+		$result = $this->Tags->merge($other->id, 1);
+		$this->assertFalse($result);
+
+		$this->assertTrue($this->Tags->exists(['id' => $other->id]));
+		$this->assertTrue($this->Tags->exists(['id' => 1]));
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testMultipleTagsPerModel() {
 		//TableRegistry::clear();
 

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -209,12 +209,12 @@ class TagsTableTest extends TestCase {
 
 		$untagged = $table->find('untaggedOne')->count();
 		$this->assertSame(2, $untagged);
-		$tagged = $table->find('taggedOne', ...['slug' => 'x'])->first();
+		$tagged = $table->find('taggedOne', value: 'x')->first();
 		$this->assertSame($entity->id, $tagged->id);
 
 		$untagged = $table->find('untaggedTwo')->count();
 		$this->assertSame(2, $untagged);
-		$tagged = $table->find('taggedTwo', ...['slug' => '66'])->first();
+		$tagged = $table->find('taggedTwo', value: '66')->first();
 		$this->assertSame($entity->id, $tagged->id);
 	}
 

--- a/tests/test_app/src/Model/Table/MultiTagsRecordsTable.php
+++ b/tests/test_app/src/Model/Table/MultiTagsRecordsTable.php
@@ -30,7 +30,7 @@ class MultiTagsRecordsTable extends Table {
 				'propertyName' => 'one',
 			],
 			'implementedFinders' => [
-				'taggedOne' => 'findByTag',
+				'taggedOne' => 'findTagged',
 				'untaggedOne' => 'findUntagged',
 			],
 			'implementedMethods' => [
@@ -47,7 +47,7 @@ class MultiTagsRecordsTable extends Table {
 				'propertyName' => 'two',
 			],
 			'implementedFinders' => [
-				'taggedTwo' => 'findByTag',
+				'taggedTwo' => 'findTagged',
 				'untaggedTwo' => 'findUntagged',
 			],
 			'implementedMethods' => [


### PR DESCRIPTION
## Summary

Major release modernizing the finder API and removing one dead config shape. Requirements unchanged (PHP 8.2+, CakePHP 5.1+).

Closes #45.

## Breaking changes

- **`find('tagged')`** — call-site key collapsed to a single fixed `value` parameter. The `finderField` config still controls which Tags column is matched against. Rector cannot rewrite this — manual change required.
- **`find('untagged')`** — replaced `array $options` with `?string $counterField = null`. The `counterField => false` overload (forced live lookup) was redundant and is dropped.
- **Method rename** `findByTag` → `findTagged`. Calls through `$query->find('tagged', ...)` are unaffected; only direct method callers need to rename.
- **`taggedCounter` config** — flat list of field names is now the canonical shape; the nested `['field' => ['conditions' => []]]` form was a no-op (its conditions were overwritten internally) and has been removed.
- **`prepareTagsForOutput()`** split into two strict-typed siblings (`prepareTagsForOutputArray`, `prepareTagsForOutputString`); the original method is kept as a dispatcher with `array|string` return so existing callers are unaffected.
- **`normalizeTags()`** declares `array|string $tags` natively (was docblock-only). No behavior change.

## Migration

See [UPGRADE.md](UPGRADE.md) for before/after examples and notes on what the cakephp/upgrade rector handles automatically.
