### PR TITLE
Add Tags.accessCheck Closure gate (opt-in defense-in-depth)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -475,6 +475,36 @@ $routes->get('/tag/:slug', ['controller' => 'Tags', 'action' => 'view'], 'my-tag
 
 For details see [Core docs](https://book.cakephp.org/5/en/development/routing.html#entity-routing).
 
+## Admin UI
+
+The plugin ships a Bootstrap 5 admin UI under `/admin/tags`.
+
+### Access control (`Tags.accessCheck`)
+
+By default the admin UI inherits the host application's `AppController` auth.
+If your host gates `/admin/*` for admins, the Tags admin is gated by the
+same mechanism. Nothing extra is required.
+
+For defense-in-depth — or if you flipped `Tags.standalone = true` and
+detached from the host AppController — set `Tags.accessCheck` to a `Closure`
+that receives the current request and returns literal `true`. Anything else
+(returns false, returns a truthy non-bool, throws) yields a 403.
+
+```php
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+
+// Example — gate by role on the authenticated identity:
+Configure::write('Tags.accessCheck', function (ServerRequest $request): bool {
+    $identity = $request->getAttribute('identity');
+    return $identity !== null && in_array('admin', (array)$identity->roles, true);
+});
+```
+
+Unset = no-op (host auth alone applies). The gate calls
+`Authorization::skipAuthorization()` when the cakephp/authorization
+component is loaded so the policy layer doesn't double-reject.
+
 ## Tips
 
 ### IDE support/help

--- a/src/Controller/Admin/TagsAppController.php
+++ b/src/Controller/Admin/TagsAppController.php
@@ -6,6 +6,11 @@ namespace Tags\Controller\Admin;
 use App\Controller\AppController;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Log\Log;
+use Closure;
+use Throwable;
 
 /**
  * TagsAppController
@@ -14,6 +19,12 @@ use Cake\Core\Configure;
  *
  * By default, extends AppController to inherit app authentication, components, and configuration.
  * Set `Tags.standalone` to `true` for an isolated admin that doesn't depend on the host app.
+ *
+ * Authorization: an optional defense-in-depth gate is available via
+ * `Tags.accessCheck`. When set to a `Closure`, it must return literal `true`
+ * for the current request to proceed; anything else (returns false, returns
+ * truthy non-bool, throws) yields a 403. Unset = no-op (the host
+ * AppController's auth is the only gate). See docs/README.md for examples.
  */
 class TagsAppController extends AppController {
 
@@ -41,6 +52,45 @@ class TagsAppController extends AppController {
 		$layout = Configure::read('Tags.adminLayout');
 		if ($layout !== false) {
 			$this->viewBuilder()->setLayout($layout ?: 'Tags.tags');
+		}
+	}
+
+	/**
+	 * Optional defense-in-depth access gate. Unset = no-op.
+	 *
+	 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+	 * @throws \Cake\Http\Exception\ForbiddenException When the configured Closure rejects the request.
+	 * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		$check = Configure::read('Tags.accessCheck');
+		if ($check === null) {
+			return;
+		}
+		if (!($check instanceof Closure)) {
+			throw new ForbiddenException('Tags.accessCheck must be a Closure');
+		}
+
+		// Coexist with cakephp/authorization: this gate IS the authorization
+		// decision for the Tags admin, so silence the policy check.
+		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+			$this->components()->get('Authorization')->skipAuthorization();
+		}
+
+		try {
+			$allowed = $check($this->request) === true;
+		} catch (ForbiddenException $e) {
+			throw $e;
+		} catch (Throwable $e) {
+			Log::warning(sprintf('Tags.accessCheck threw %s: %s', $e::class, $e->getMessage()));
+
+			throw new ForbiddenException('Tags admin access denied');
+		}
+
+		if (!$allowed) {
+			throw new ForbiddenException('Tags admin access denied');
 		}
 	}
 

--- a/tests/TestCase/Controller/Admin/TagsAppControllerTest.php
+++ b/tests/TestCase/Controller/Admin/TagsAppControllerTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace Tags\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 class TagsAppControllerTest extends TestCase {
 
@@ -36,6 +38,7 @@ class TagsAppControllerTest extends TestCase {
 
 		Configure::delete('Tags.standalone');
 		Configure::delete('Tags.adminLayout');
+		Configure::delete('Tags.accessCheck');
 	}
 
 	/**
@@ -70,6 +73,115 @@ class TagsAppControllerTest extends TestCase {
 		$this->get('/admin/tags/tags');
 
 		$this->assertResponseOk();
+	}
+
+	/**
+	 * Without an accessCheck configured, the gate is a no-op (host
+	 * AppController auth alone applies). Default behavior, no breaking change.
+	 *
+	 * @return void
+	 */
+	public function testAccessCheckUnsetIsNoOp(): void {
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+	}
+
+	/**
+	 * A non-Closure value is rejected immediately so a misconfigured key does
+	 * not silently allow access.
+	 *
+	 * @return void
+	 */
+	public function testAccessCheckNonClosureRejects(): void {
+		Configure::write('Tags.accessCheck', 'not a closure');
+
+		$this->expectException(ForbiddenException::class);
+		$this->get('/admin/tags/tags');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAccessCheckClosureFalseRejects(): void {
+		Configure::write('Tags.accessCheck', fn () => false);
+
+		$this->expectException(ForbiddenException::class);
+		$this->get('/admin/tags/tags');
+	}
+
+	/**
+	 * Truthy non-bool returns are rejected (no coercion).
+	 *
+	 * @return void
+	 */
+	public function testAccessCheckRequiresStrictTrue(): void {
+		Configure::write('Tags.accessCheck', fn () => 1);
+
+		$this->expectException(ForbiddenException::class);
+		$this->get('/admin/tags/tags');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAccessCheckClosureTrueAllows(): void {
+		Configure::write('Tags.accessCheck', fn () => true);
+
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+	}
+
+	/**
+	 * A throwing Closure is converted to 403 (the original exception is
+	 * logged, the client sees a generic forbidden).
+	 *
+	 * @return void
+	 */
+	public function testAccessCheckThrowingYields403(): void {
+		Configure::write('Tags.accessCheck', function (): bool {
+			throw new RuntimeException('oops');
+		});
+
+		$this->expectException(ForbiddenException::class);
+		$this->get('/admin/tags/tags');
+	}
+
+	/**
+	 * A Closure that itself throws ForbiddenException is respected as-is so
+	 * callers can short-circuit with their own message.
+	 *
+	 * @return void
+	 */
+	public function testAccessCheckExplicitForbiddenIsRespected(): void {
+		Configure::write('Tags.accessCheck', function (): bool {
+			throw new ForbiddenException('custom denial reason');
+		});
+
+		$this->expectException(ForbiddenException::class);
+		$this->expectExceptionMessage('custom denial reason');
+		$this->get('/admin/tags/tags');
+	}
+
+	/**
+	 * The Closure receives the request, so callers can inspect path/identity/etc.
+	 *
+	 * @return void
+	 */
+	public function testAccessCheckReceivesRequest(): void {
+		$received = null;
+		Configure::write('Tags.accessCheck', function ($request) use (&$received): bool {
+			$received = $request;
+
+			return true;
+		});
+
+		$this->get('/admin/tags/tags');
+
+		$this->assertResponseOk();
+		$this->assertNotNull($received);
+		$this->assertStringContainsString('tags', $received->getPath());
 	}
 
 }


### PR DESCRIPTION
## Summary

Adds an optional `Tags.accessCheck` Closure gate to the admin backend. Set it and it runs as a defense-in-depth check on top of whatever auth the host `AppController` provides; leave it unset and nothing changes (current behavior preserved). Non-breaking.

## Why

The plugin's admin backend at `/admin/tags` inherits the host `AppController`'s auth by default — that part is unchanged. The new knob is for two cases:

1. **Defense in depth.** Hosts that already gate `/admin/*` for admins can additionally tighten the Tags admin (e.g. require a specific role) without modifying the host `AppController`.
2. **Standalone mode.** When `Tags.standalone = true`, the plugin detaches from the host `AppController` and per-controller auth wired through it (component loads, `isAuthorized()`, `beforeFilter()` admin checks) no longer runs. Setting `Tags.accessCheck` is how you re-establish a plugin-side gate in that mode.

## Behavior

- **Unset** (default) → no-op. Host auth alone applies. **No breaking change.**
- **Non-`Closure` value** (e.g. accidental string) → `403`. A misconfigured key fails closed.
- **`Closure` returns literal `true`** → request proceeds.
- **`Closure` returns `false` / truthy non-bool** → `403`.
- **`Closure` throws `ForbiddenException`** → respected as-is (caller can short-circuit with their own message).
- **`Closure` throws any other `Throwable`** → logged via `Cake\Log\Log` and converted to a generic `403` (no stack trace leaked to the client).

Calls `Authorization::skipAuthorization()` when the cakephp/authorization component is loaded, so the gate doesn't conflict with policy-based authorization — the gate is the authorization decision for these controllers.

## Example

```php
use Cake\Core\Configure;
use Cake\Http\ServerRequest;

Configure::write('Tags.accessCheck', function (ServerRequest $request): bool {
    $identity = $request->getAttribute('identity');
    return $identity !== null && in_array('admin', (array)$identity->roles, true);
});
```

## Tests

8 new test cases in `TagsAppControllerTest` cover all branches: unset, non-Closure, Closure returns false / truthy non-bool / true, throwing, explicit `ForbiddenException` pass-through, and the request being forwarded to the Closure. All 145 existing tests still pass.

## Checklist

- [x] phpunit (145/145)
- [x] phpcs clean
- [x] phpstan clean
- [x] Docs updated (`docs/README.md` Admin UI section)
