### PR TITLE
Wrap moveNamespace conflict check + update in a transaction

### DIFF
--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -241,24 +241,31 @@ class TagsTable extends Table {
 	/**
 	 * Move all tags from one namespace to another.
 	 *
+	 * The conflict check and the update run inside a single transaction so a
+	 * concurrent insert in the target namespace cannot slip a colliding slug in
+	 * between the count and the bulk update (which would corrupt the unique
+	 * `(namespace, slug)` invariant).
+	 *
 	 * @param string|null $fromNamespace Source namespace.
 	 * @param string|null $toNamespace Target namespace.
 	 * @throws \RuntimeException When duplicate slugs already exist in the target namespace.
 	 * @return int Number of updated rows.
 	 */
 	public function moveNamespace(?string $fromNamespace, ?string $toNamespace): int {
-		$conflicts = $this->countNamespaceConflicts($fromNamespace, $toNamespace);
-		if ($conflicts) {
-			throw new RuntimeException(sprintf(
-				'Cannot move namespace: %d conflicting slug(s) already exist in the target namespace.',
-				$conflicts,
-			));
-		}
+		return $this->getConnection()->transactional(function () use ($fromNamespace, $toNamespace): int {
+			$conflicts = $this->countNamespaceConflicts($fromNamespace, $toNamespace);
+			if ($conflicts) {
+				throw new RuntimeException(sprintf(
+					'Cannot move namespace: %d conflicting slug(s) already exist in the target namespace.',
+					$conflicts,
+				));
+			}
 
-		return $this->updateAll(
-			['namespace' => $toNamespace],
-			$this->namespaceConditions($fromNamespace),
-		);
+			return $this->updateAll(
+				['namespace' => $toNamespace],
+				$this->namespaceConditions($fromNamespace),
+			);
+		});
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -5,6 +5,7 @@ namespace Tags\Test\TestCase\Model\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use RuntimeException;
 use Tools\Utility\Text;
 
 class TagsTableTest extends TestCase {
@@ -174,6 +175,38 @@ class TagsTableTest extends TestCase {
 
 		$this->expectExceptionMessage('conflicting slug(s)');
 		$this->Tags->moveNamespace(null, 'palette');
+	}
+
+	/**
+	 * Verifies the conflict-detection branch rolls back: source-namespace tags
+	 * stay in their original namespace when the move is rejected.
+	 *
+	 * @return void
+	 */
+	public function testMoveNamespaceConflictRollsBack(): void {
+		$entity = $this->Tags->newEntity([
+			'namespace' => 'palette',
+			'slug' => 'color',
+			'label' => 'Color In Palette',
+		]);
+		$this->Tags->saveOrFail($entity);
+
+		$beforeNullCount = $this->Tags->find()
+			->where(['namespace IS' => null])
+			->count();
+
+		try {
+			$this->Tags->moveNamespace(null, 'palette');
+			$this->fail('Expected RuntimeException was not thrown.');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('conflicting slug(s)', $e->getMessage());
+		}
+
+		$afterNullCount = $this->Tags->find()
+			->where(['namespace IS' => null])
+			->count();
+
+		$this->assertSame($beforeNullCount, $afterNullCount, 'No source rows should have been moved.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `TagsTable::moveNamespace()` previously ran `countNamespaceConflicts()` (a SELECT) and `updateAll()` as two separate statements. Between the two, a concurrent insert in the target namespace could slip a colliding slug past the guard and corrupt the unique `(namespace, slug)` invariant the validator at `src/Model/Table/TagsTable.php:64-70` is supposed to enforce.
- Wrapped both calls in `getConnection()->transactional(...)` at `src/Model/Table/TagsTable.php:249` so the conflict check and the bulk update are atomic; on conflict the existing `RuntimeException` now also rolls back any partial write inside the same transaction frame.
- Added `testMoveNamespaceConflictRollsBack` to lock in that source-namespace rows stay put when the move is rejected.

This brings `moveNamespace()` in line with the `merge()` semantics, which already wraps its multi-statement work in `transactional()`.