### PR TITLE
Make tags_tagged.fk_id type configurable via Polymorphic.type

### DIFF
--- a/config/Migrations/20180113144821_MigrationTagsInit.php
+++ b/config/Migrations/20180113144821_MigrationTagsInit.php
@@ -33,7 +33,16 @@ class MigrationTagsInit extends BaseMigration {
 		// reference primary keys, so they follow the application's primary-key
 		// signedness. The flag is false (signed) when unset, so an unset flag yields
 		// signed columns matching the default-signed ids they reference. Unsigned only on MySQL.
+		$type = (string)Configure::read('Polymorphic.type', 'integer');
 		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
+		$polymorphicOptions = [
+			'default' => null,
+			'null' => true,
+		];
+		if (in_array($type, ['integer', 'biginteger'], true)) {
+			$polymorphicOptions['signed'] = $signed;
+		}
 
 		$table = $this->table('tags_tags');
 		$table->addColumn('namespace', 'string', [
@@ -74,12 +83,7 @@ class MigrationTagsInit extends BaseMigration {
 			'null' => true,
 			'signed' => $signed,
 		]);
-		$table->addColumn('fk_id', 'integer', [
-			'default' => null,
-			'length' => 11,
-			'null' => true,
-			'signed' => $signed,
-		]);
+		$table->addColumn('fk_id', $type, $polymorphicOptions);
 		$table->addColumn('fk_table', 'string', [
 			'default' => null,
 			'limit' => 255,

--- a/config/Migrations/20180113144821_MigrationTagsInit.php
+++ b/config/Migrations/20180113144821_MigrationTagsInit.php
@@ -29,7 +29,7 @@ class MigrationTagsInit extends BaseMigration {
 	 * @return void
 	 */
 	public function change() {
-		// tags_tagged.tag_id (the plugin's own tags.id) and fk_id (the host record)
+		// tags_tagged.tag_id (the plugin's own tags_tags.id) and fk_id (the host record)
 		// reference primary keys, so they follow the application's primary-key
 		// signedness. The flag is false (signed) when unset, so an unset flag yields
 		// signed columns matching the default-signed ids they reference. Unsigned only on MySQL.

--- a/docs/README.md
+++ b/docs/README.md
@@ -441,16 +441,35 @@ If you want to use custom slugging, use the `'slug'` callable you can provide to
 }
 ```
 
+### Polymorphic foreign key type (`Polymorphic.type`)
+
+The `tags_tagged.fk_id` column holds the primary key of the host record and is
+therefore polymorphic — it must match the type of whichever model is being tagged.
+You can control its column type globally via the `Polymorphic.type` config key:
+
+```php
+// config/app.php or config/app_local.php
+Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
+```
+
+- `integer` (default) — standard signed/unsigned integer; signedness follows `Migrations.unsigned_primary_keys`.
+- `biginteger` — 64-bit integer; signedness follows `Migrations.unsigned_primary_keys`.
+- `uuid` — UUID string (36 chars). No `signed` option is set.
+- `binaryuuid` — binary UUID. No `signed` option is set.
+
+Note: `tags_tagged.tag_id` always stays `integer` — it references the plugin's own
+`tags_tags.id` primary key which is never polymorphic.
+
 ### UUIDs
 By default, the plugin works with AIIDs (auto-incremental IDs). This usually suffices, as the tags are usually not exposes via ID, but via slug.
 As such the internal ID is usually not leaking to the outside.
-If you, for some reason, still need to use UUIDs, please copy over the schema to your project's `/config/Migrations/` folder and adjust the primary key in the migration files to `'type' => 'uuid', 'length' => 36, 'null' => false`.
+If you, for some reason, still need to use UUIDs for the plugin's own `tags_tags` table primary key, please copy over the schema to your project's `/config/Migrations/` folder and adjust the primary key in the migration files to `'type' => 'uuid', 'length' => 36, 'null' => false`.
 
 Make sure you didn't add any validation like "numeric" here, only "scalar" ideally.
 See the test cases (and fixtures for UUIDs) for details.
 
-If you would like to tag (at least) one model that uses an UUID as a primary key, you will need to adjust the migration and change the foreign key field `fk_id` from `integer` to `uuid` as well.
-This will work with UUIDs as well as with AIIDs.
+If you would like to tag models that use a UUID as a primary key, set `Polymorphic.type` to `uuid`
+(see section above) instead of manually patching the migration.
 
 ### Entity Routing
 If you create your own APP Tags controller, you can easily have EntityRouting set up for it:

--- a/docs/README.md
+++ b/docs/README.md
@@ -448,17 +448,23 @@ therefore polymorphic — it must match the type of whichever model is being tag
 You can control its column type globally via the `Polymorphic.type` config key:
 
 ```php
-// config/app.php or config/app_local.php
-Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
+// config/app.php (merged into Configure at bootstrap, including the migrations CLI)
+'Polymorphic' => [
+    'type' => 'uuid', // integer (default) | biginteger | uuid | binaryuuid
+],
 ```
+
+This setting only affects fresh installs. Existing installs need an app-side migration to change the column type.
 
 - `integer` (default) — standard signed/unsigned integer; signedness follows `Migrations.unsigned_primary_keys`.
 - `biginteger` — 64-bit integer; signedness follows `Migrations.unsigned_primary_keys`.
 - `uuid` — UUID string (36 chars). No `signed` option is set.
 - `binaryuuid` — binary UUID. No `signed` option is set.
 
-Note: `tags_tagged.tag_id` always stays `integer` — it references the plugin's own
-`tags_tags.id` primary key which is never polymorphic.
+Note: `tags_tagged.tag_id` is not governed by `Polymorphic.type` — it is a plain
+`integer` that references `tags_tags.id`, which is the plugin's own primary key and
+is not polymorphic. If you switch `tags_tags.id` to UUID (see the UUIDs section
+below), `tag_id` must be updated to match via an app-side migration.
 
 ### UUIDs
 By default, the plugin works with AIIDs (auto-incremental IDs). This usually suffices, as the tags are usually not exposes via ID, but via slug.


### PR DESCRIPTION
## Problem

`tags_tagged.fk_id` is a polymorphic reference — it points at an arbitrary host record's primary key, so its column type should match whatever the host uses. It was hardcoded as `integer`, which cannot match apps whose host records use `biginteger` or UUID primary keys.

## Fix

The polymorphic column now follows a single global config key, `Polymorphic.type`, shared across the polymorphic-FK plugins:

```php
// config/app.php or config/app_local.php
Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
```

- Default `integer` (the CakePHP default), so behavior is unchanged for the common case.
- For the integer variants, signedness follows `Migrations.unsigned_primary_keys`; `uuid` / `binaryuuid` set no signedness.
- `tag_id` stays `integer` — it references the plugin's own `tags.id`, not a polymorphic host.

Editing the create migration sets the default for fresh installs; existing installs are unaffected (the create migration does not re-run). Type/signedness only take effect on MySQL for the integer variants.
