### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/TagCloudHelper.php
+++ b/src/View/Helper/TagCloudHelper.php
@@ -25,7 +25,7 @@ class TagCloudHelper extends Helper {
 	use StringTemplateTrait;
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = [
 		'Html',

--- a/src/View/Helper/TagHelper.php
+++ b/src/View/Helper/TagHelper.php
@@ -24,7 +24,7 @@ class TagHelper extends Helper {
 	/**
 	 * Other helpers to load
 	 *
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = [
 		'Form',


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test